### PR TITLE
Preserve HTTP source refresh timing on import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers-app",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/renderer/hooks/useHttp.jsx
+++ b/src/renderer/hooks/useHttp.jsx
@@ -238,8 +238,10 @@ export function useHttp() {
 
         console.log(`Source ${sourceId} skipImmediateRefresh: ${skipImmediateRefresh}`);
 
-        // Check for invalid or expired nextRefresh time
-        if (!nextRefresh || nextRefresh <= now) {
+        // Check if we have a valid nextRefresh time
+        const hasValidNextRefresh = nextRefresh && nextRefresh > now;
+
+        if (!hasValidNextRefresh) {
             if (skipImmediateRefresh) {
                 // If we should skip the immediate refresh, schedule for future
                 nextRefresh = now + intervalMs;
@@ -249,6 +251,11 @@ export function useHttp() {
                 nextRefresh = now;
                 console.log(`Source ${sourceId} needs immediate refresh - scheduling now`);
             }
+        } else {
+            // We have a valid future time for nextRefresh
+            console.log(`Source ${sourceId} has valid nextRefresh time: ${new Date(nextRefresh).toISOString()}`);
+            const timeUntilNextRefresh = Math.round((nextRefresh - now) / 1000);
+            console.log(`Source ${sourceId} will refresh in ${timeUntilNextRefresh} seconds (${Math.round(timeUntilNextRefresh/60)} minutes)`);
         }
 
         const timeUntilRefresh = Math.max(0, nextRefresh - now);


### PR DESCRIPTION
## Description
This PR fixes an issue where HTTP sources with auto-refresh enabled would immediately
refresh when imported from a configuration file, instead of respecting the remaining
time until the next refresh from the original export.

## Changes Made
- Enhanced the `exportSources` function to include complete refresh timing information
- Added logic in `importSources` to detect and flag sources with valid timing data
- Modified the `addSource` function to check for and respect preserved timing
- Updated `setupRefresh` to honor existing nextRefresh times for imported sources
- Fixed `updateSourceContent` to avoid overwriting preserved nextRefresh timestamps
- Improved the SourceTable UI to display the actual remaining time until refresh

## Testing
- Tested by exporting a configuration with HTTP sources having active refresh timers
- Imported the configuration and verified the UI shows the correct remaining time
- Confirmed that the source doesn't refresh immediately but waits for the original schedule
- Tested on macOS

## Screenshots
N/A

## Related Issues
N/A