### PR TITLE
Add sticky "Add Source" button for improved UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers-app",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -199,14 +199,16 @@ const AppComponent = () => {
             </Header>
 
             <Content className="app-content">
-                <SourceForm onAddSource={handleAddSource} />
+                <div className="content-container">
+                    <SourceForm onAddSource={handleAddSource} />
 
-                <SourceTable
-                    sources={sources}
-                    onRemoveSource={removeSource}
-                    onRefreshSource={refreshSource}
-                    onUpdateRefreshOptions={updateRefreshOptions}
-                />
+                    <SourceTable
+                        sources={sources}
+                        onRemoveSource={removeSource}
+                        onRefreshSource={refreshSource}
+                        onUpdateRefreshOptions={updateRefreshOptions}
+                    />
+                </div>
             </Content>
 
             <SettingsModal

--- a/src/renderer/App.less
+++ b/src/renderer/App.less
@@ -44,6 +44,11 @@
 .app-content {
   padding: 24px;
   background: #f5f5f7;
+
+  .content-container {
+    padding-bottom: 40px; // Add extra padding at the bottom for scrolling
+    min-height: calc(100vh - 112px); // 100vh - (header height + padding)
+  }
 }
 
 // Card styles
@@ -64,6 +69,8 @@
 // Source form styles
 .source-form-card {
   margin-bottom: 24px;
+  position: relative;
+  z-index: 1;
 
   .ant-form-item {
     margin-bottom: 12px;
@@ -99,6 +106,37 @@
 
   .ant-divider {
     margin: 8px 0;
+  }
+}
+
+// Sticky source form header - only for the add button header
+.source-form-sticky-header {
+  position: fixed;
+  top: 64px; // Same as app-header height
+  left: 0;
+  right: 0;
+  z-index: 9;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.3s, transform 0.3s;
+  padding: 0 24px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .sticky-header-content {
+    width: 100%;
+    max-width: 1200px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .title {
+      font-size: 14px;
+      font-weight: 500;
+      color: rgba(0, 0, 0, 0.85);
+    }
   }
 }
 


### PR DESCRIPTION
## Sticky "Add Source" Button

This MR implements a UX improvement that makes the "Add Source" button always accessible when scrolling through the sources list.

### Problem
When users have many sources in their list, they need to scroll back to the top of the page to add a new source, which disrupts their workflow.

### Solution
Added a floating header that appears when the user scrolls past the source form. This header contains only the "Add Source" button and title, providing quick access without taking up too much screen space.

### Implementation Details
- Added scroll event detection in the SourceForm component
- Created a separate floating header with minimal design
- Implemented conditional rendering based on scroll position
- Added styling for smooth transitions
- Ensured the sticky header doesn't cover too much of the content area

### Testing
- Tested with various screen sizes
- Verified functionality with both short and long source lists
- Confirmed that expanded HTTP options don't interfere with usability

### Screenshots
N/A