### PR TITLE
Preserve HTTP header case and rename originalJson to originalRe…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers-app",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -546,10 +546,21 @@ async function handleMakeHttpRequest(_, url, method, options = {}) {
                 });
 
                 res.on('end', () => {
+                    // Create headers object from the raw headers to preserve case
+                    const preservedHeaders = {};
+                    const rawHeaders = res.rawHeaders;
+
+                    // rawHeaders is an array with alternating key, value pairs
+                    for (let i = 0; i < rawHeaders.length; i += 2) {
+                        const headerName = rawHeaders[i];
+                        const headerValue = rawHeaders[i + 1];
+                        preservedHeaders[headerName] = headerValue;
+                    }
+
                     // Format response
                     const response = {
                         statusCode: res.statusCode,
-                        headers: res.headers,
+                        headers: preservedHeaders,
                         body: data
                     };
 

--- a/src/renderer/components/EditSourceModal.jsx
+++ b/src/renderer/components/EditSourceModal.jsx
@@ -260,7 +260,7 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                 // Set saving state
                 setSaving(true);
 
-                // FIXED: Always create a clean and normalized jsonFilter object
+                // Always create a clean and normalized jsonFilter object
                 const normalizedJsonFilter = {
                     enabled: Boolean(jsonFilter?.enabled),
                     path: jsonFilter?.enabled === true ? (jsonFilter.path || '') : ''
@@ -270,7 +270,7 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                 console.log(`Normalized JSON filter for source ${source.sourceId}:`,
                     JSON.stringify(normalizedJsonFilter));
 
-                // Get TOTP values - CRITICAL FIX: collect from multiple sources
+                // Get TOTP values - collect from multiple sources
                 // First check form values
                 let isTotpEnabled = values.enableTOTP === true;
                 let totpSecretValue = values.totpSecret || '';
@@ -303,7 +303,7 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                     secret: totpSecretValue ? "exists" : "none"
                 });
 
-                // Prepare source data for update
+                // Prepare source data for update - preserve originalResponse if available
                 const sourceData = {
                     sourceId: source.sourceId,
                     sourceType: source.sourceType,
@@ -318,13 +318,18 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                         body: values.requestOptions?.body || source.requestOptions?.body || null,
                         contentType: values.requestOptions?.contentType || source.requestOptions?.contentType || 'application/json'
                     },
-                    // FIXED: Use our normalized jsonFilter object
+                    // Use normalized jsonFilter object
                     jsonFilter: normalizedJsonFilter,
                     refreshOptions: values.refreshOptions || { enabled: false, interval: 0 },
                     refreshNow: refreshNow
                 };
 
-                // IMPORTANT FIX: Explicitly add TOTP values to requestOptions if enabled
+                // Preserve the original response if it exists
+                if (source.originalResponse) {
+                    sourceData.originalResponse = source.originalResponse;
+                }
+
+                // Explicitly add TOTP values to requestOptions if enabled
                 if (isTotpEnabled && totpSecretValue) {
                     sourceData.requestOptions.totpSecret = totpSecretValue;
                     console.log("Added TOTP secret to requestOptions for saving");
@@ -350,7 +355,7 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                             return;
                         }
 
-                        // FIXED: Normalize the jsonFilter from the component
+                        // Normalize the jsonFilter from the component
                         sourceData.jsonFilter = {
                             enabled: Boolean(jsonFilterState.enabled),
                             path: jsonFilterState.enabled === true ? (jsonFilterState.path || '') : ''

--- a/src/renderer/components/SourceForm.jsx
+++ b/src/renderer/components/SourceForm.jsx
@@ -130,7 +130,7 @@ const SourceForm = ({ onAddSource }) => {
                     console.log("Adding TOTP secret to request options");
                 }
 
-                // If we have test response, extract content and original JSON
+                // If we have test response, extract content and original response
                 if (testResponse) {
                     try {
                         const parsedResponse = JSON.parse(testResponse);
@@ -148,15 +148,18 @@ const SourceForm = ({ onAddSource }) => {
                             // For filtered responses, handle differently
                             if (parsedResponse.filteredWith && sourceData.jsonFilter?.enabled) {
                                 sourceData.initialContent = parsedResponse.body; // This is already filtered
-                                sourceData.originalJson = parsedResponse.originalBody || parsedResponse.body; // Use original if available
-                                console.log('Setting filtered content and original JSON:',
+
+                                // Use originalBody for the original response
+                                sourceData.originalResponse = parsedResponse.originalBody || parsedResponse.body;
+
+                                console.log('Setting filtered content and original response:',
                                     'filtered:', sourceData.initialContent.substring(0, 50) + '...',
-                                    'original:', sourceData.originalJson.substring(0, 50) + '...');
+                                    'original:', sourceData.originalResponse.substring(0, 50) + '...');
                             } else {
                                 // For non-filtered responses
                                 sourceData.initialContent = parsedResponse.body;
-                                sourceData.originalJson = parsedResponse.body;
-                                console.log('Setting initial originalJson from test response:',
+                                sourceData.originalResponse = parsedResponse.body;
+                                console.log('Setting initial originalResponse from test response:',
                                     parsedResponse.body.substring(0, 50) + '...');
                             }
 
@@ -170,7 +173,7 @@ const SourceForm = ({ onAddSource }) => {
                         console.error("Error parsing test response:", error);
                         // Use raw response if parsing fails
                         sourceData.initialContent = testResponse;
-                        sourceData.originalJson = testResponse;
+                        sourceData.originalResponse = testResponse;
 
                         // Try to include raw response for potential header extraction
                         sourceData.rawResponse = testResponse;

--- a/src/renderer/contexts/SourceContext.jsx
+++ b/src/renderer/contexts/SourceContext.jsx
@@ -1,9 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
-import { App } from 'antd';
 import { useFileSystem } from '../hooks/useFileSystem';
 import { useHttp } from '../hooks/useHttp';
 import { useEnv } from '../hooks/useEnv';
-import { createRoot } from 'react-dom/client';
 import { showMessage } from '../utils/messageUtil'; // Import the utility function
 
 // Create context
@@ -82,7 +80,6 @@ export function SourceProvider({ children }) {
                         if (key === 'refreshOptions' && source.refreshOptions) {
                             // Special handling for refreshOptions to ensure we preserve existing values
 
-                            // IMPROVED: More sophisticated check for refresh timing preservation
                             // Check if we need to preserve the existing timing
                             const preserveTiming = (
                                 // If source explicitly says to preserve timing
@@ -123,19 +120,23 @@ export function SourceProvider({ children }) {
                                     debugLog(`Updated refresh timing for source ${sourceId}: next=${new Date(additionalData.refreshOptions.nextRefresh).toISOString()}`);
                                 }
                             }
-                        } else if (key === 'originalJson') {
-                            // Handle originalJson updates
-                            updatedSource.originalJson = additionalData.originalJson;
-                            console.log(`Updated originalJson for source ${sourceId}`);
-                        } else if (key === 'headers') {
+                        }
+                        else if (key === 'originalResponse') {
+                            // Handle originalResponse updates
+                            updatedSource.originalResponse = additionalData.originalResponse;
+                            console.log(`Updated originalResponse for source ${sourceId}`);
+                        }
+                        else if (key === 'headers') {
                             // Handle headers updates
                             updatedSource.headers = additionalData.headers;
                             console.log(`Updated headers for source ${sourceId}:`, additionalData.headers);
-                        } else if (key === 'rawResponse') {
+                        }
+                        else if (key === 'rawResponse') {
                             // Store the raw response
                             updatedSource.rawResponse = additionalData.rawResponse;
                             console.log(`Updated rawResponse for source ${sourceId}`);
-                        } else {
+                        }
+                        else {
                             // Handle any other properties
                             updatedSource[key] = additionalData[key];
                         }
@@ -479,10 +480,10 @@ export function SourceProvider({ children }) {
                     if (sourceData.initialContent) {
                         initialContent = sourceData.initialContent;
 
-                        // Make sure originalJson and headers are also set if available
-                        if (sourceData.originalJson) {
+                        // Make sure originalResponse and headers are also set if available
+                        if (sourceData.originalResponse) {
                             if (isMounted.current) {
-                                const updateData = { originalJson: sourceData.originalJson };
+                                const updateData = { originalResponse: sourceData.originalResponse };
 
                                 // If headers are provided, include them
                                 if (sourceData.headers) {
@@ -507,22 +508,22 @@ export function SourceProvider({ children }) {
                         );
 
                         // Destructure with all possible properties
-                        const { content, originalJson, headers, rawResponse } = result;
+                        const { content, originalResponse, headers, rawResponse } = result;
                         initialContent = content;
 
                         // Update with all available data
                         if (isMounted.current) {
                             debugLog(`Updating source ${sourceId} with HTTP response`);
                             const updateData = {
-                                originalJson,
-                                headers, // Include headers
-                                rawResponse // Include raw response
+                                originalResponse,
+                                headers,
+                                rawResponse
                             };
 
                             // Log what we're storing
                             console.log(`Storing headers for source ${sourceId}:`, headers);
-                            console.log(`Storing originalJson for source ${sourceId}:`,
-                                originalJson ? originalJson.substring(0, 50) + '...' : 'undefined');
+                            console.log(`Storing originalResponse for source ${sourceId}:`,
+                                updateData.originalResponse ? updateData.originalResponse.substring(0, 50) + '...' : 'undefined');
 
                             updateSourceContent(sourceId, initialContent, updateData);
                         }
@@ -1100,9 +1101,9 @@ export function SourceProvider({ children }) {
                         nextRefresh: refreshOptions.nextRefresh || null
                     };
 
-                    // Include originalJson if available (for filtering capability)
-                    if (source.originalJson) {
-                        exportedSource.originalJson = source.originalJson;
+                    // Include originalResponse if available
+                    if (source.originalResponse) {
+                        exportedSource.originalResponse = source.originalResponse;
                     }
 
                     // Include headers if available

--- a/src/renderer/utils/MessageProvider.jsx
+++ b/src/renderer/utils/MessageProvider.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect } from 'react';
+import React, { createContext, useContext } from 'react';
 import { message } from 'antd';
 
 // Create a context for the message API


### PR DESCRIPTION
## HTTP Header Case Preservation and Field Renaming

This MR implements two important improvements to how we handle HTTP responses:

1. **Header Case Preservation**: Modified the main process to preserve the original case of HTTP response headers instead of converting all headers to lowercase. This provides better standards compliance and compatibility with external systems that might be case-sensitive.

2. **Field Renaming**: Renamed the `originalJson` field to `originalResponse` to better reflect that this field can contain any type of HTTP response content (HTML, XML, plain text), not just JSON.

### Implementation Details

- **Header Case Preservation**: Updated `handleMakeHttpRequest` in main.js to use `res.rawHeaders` to extract headers with their original case
- **Field Renaming**: Updated the following files to use `originalResponse` instead of `originalJson`:
  - `useHttp.jsx` - Return value from request functions
  - `SourceContext.jsx` - Storage and state management
  - `ContentViewer.jsx` - Display and header extraction
  - `SourceForm.jsx` - Source creation
  - `EditSourceModal.jsx` - Source editing

### Testing

- Tested HTTP requests to various endpoints with different header cases
- Verified all HTTP headers maintain their original case in the UI and export/import
- Confirmed the renamed field works properly during source creation, editing, and export/import
- Ensured all HTTP source features continue to work properly (TOTP auth, JSON filtering, auto-refresh)

### Screenshots

N/A