### PR TITLE
Add version display and about modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers-app",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/preload.js
+++ b/src/preload.js
@@ -11,6 +11,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     watchFile: (sourceId, filePath) => ipcRenderer.invoke('watchFile', sourceId, filePath),
     unwatchFile: (filePath) => ipcRenderer.invoke('unwatchFile', filePath),
 
+    openExternal: (url) => ipcRenderer.invoke('openExternal', url),
+
+    // Added: App version
+    getAppVersion: () => ipcRenderer.invoke('getAppVersion'),
+
     updateWebSocketSources: (sources) => {
         ipcRenderer.send('updateWebSocketSources', sources);
     },

--- a/src/renderer/App.less
+++ b/src/renderer/App.less
@@ -32,9 +32,23 @@
       margin-right: 16px;
     }
 
-    h3 {
-      color: #1d1d1f;
-      margin: 0;
+    .title-version {
+      display: flex;
+      align-items: center;
+
+      h3 {
+        color: #1d1d1f;
+        margin: 0;
+        margin-right: 8px;
+      }
+
+      .version-tag {
+        margin-top: 3px; // Slight adjustment to align with title
+        font-size: 12px;
+        padding: 0 7px;
+        font-weight: normal;
+        opacity: 0.85;
+      }
     }
   }
 }

--- a/src/renderer/components/AboutModal.jsx
+++ b/src/renderer/components/AboutModal.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Modal, Typography, Space, Button, Divider, Row, Col } from 'antd';
+import {
+    GithubOutlined,
+    QuestionCircleOutlined,
+    ChromeOutlined,
+    CompassOutlined,
+    SafetyCertificateOutlined
+} from '@ant-design/icons';
+
+const { Title, Text, Link, Paragraph } = Typography;
+
+/**
+ * AboutModal component to display app information
+ */
+const AboutModal = ({ open, onClose, appVersion }) => {
+    // Helper function to open external links
+    const openExternal = (url) => {
+        if (window.electronAPI && window.electronAPI.openExternal) {
+            window.electronAPI.openExternal(url);
+        } else {
+            window.open(url, '_blank');
+        }
+    };
+
+    return (
+        <Modal
+            title={
+                <Space align="center">
+                    <QuestionCircleOutlined />
+                    <span>About Open Headers</span>
+                </Space>
+            }
+            open={open}
+            onCancel={onClose}
+            footer={[
+                <Button key="close" onClick={onClose}>
+                    Close
+                </Button>
+            ]}
+            width={500}
+        >
+            <div className="about-modal-content">
+                <div className="app-info" style={{ textAlign: 'center', marginBottom: 20 }}>
+                    <img
+                        src="./images/icon128.png"
+                        alt="Open Headers Logo"
+                        style={{ width: 80, height: 80, marginBottom: 16 }}
+                    />
+                    <Title level={4} style={{ marginBottom: 4 }}>Open Headers - Dynamic Sources</Title>
+                    {appVersion && (
+                        <Text type="secondary">Version {appVersion}</Text>
+                    )}
+                </div>
+
+                <Paragraph>
+                    A companion application for the Open Headers browser extension that manages dynamic sources from files, environment variables, and HTTP endpoints.
+                </Paragraph>
+
+                <Divider />
+
+                <Row gutter={[8, 16]}>
+                    <Col span={12}>
+                        <Button
+                            type="link"
+                            icon={<GithubOutlined />}
+                            onClick={() => openExternal('https://github.com/OpenHeaders/open-headers-app')}
+                            style={{ textAlign: 'left', padding: 0 }}
+                        >
+                            GitHub Repository
+                        </Button>
+                    </Col>
+                    <Col span={12}>
+                        <Button
+                            type="link"
+                            icon={<ChromeOutlined />}
+                            onClick={() => openExternal('https://chromewebstore.google.com/detail/ablaikadpbfblkmhpmbbnbbfjoibeejb')}
+                            style={{ textAlign: 'left', padding: 0 }}
+                        >
+                            Chrome Extension
+                        </Button>
+                    </Col>
+                    <Col span={12}>
+                        <Button
+                            type="link"
+                            icon={<CompassOutlined />}
+                            onClick={() => openExternal('https://microsoftedge.microsoft.com/addons/detail/open-headers/gnbibobkkddlflknjkgcmokdlpddegpo')}
+                            style={{ textAlign: 'left', padding: 0 }}
+                        >
+                            Edge Extension
+                        </Button>
+                    </Col>
+                    <Col span={12}>
+                        <Button
+                            type="link"
+                            icon={<SafetyCertificateOutlined />}
+                            onClick={() => openExternal('https://addons.mozilla.org/en-US/firefox/addon/open-headers/')}
+                            style={{ textAlign: 'left', padding: 0 }}
+                        >
+                            Firefox Extension
+                        </Button>
+                    </Col>
+                </Row>
+
+                <Divider />
+
+                <Paragraph style={{ marginBottom: 0 }}>
+                    <Text type="secondary">
+                        © 2025 Open Headers
+                    </Text>
+                </Paragraph>
+            </div>
+        </Modal>
+    );
+};
+
+export default AboutModal;


### PR DESCRIPTION
## Version Display and About Modal

This MR introduces version information display and an About modal to improve the user experience and provide easy access to related resources.

### Changes
- Added version number display in the header next to the app title
- Created a new About modal component accessible from the menu dropdown
- Added direct links to GitHub repository and browser extensions (Chrome, Edge, Firefox)
- Implemented secure external URL handling with domain validation
- Updated main process to allow opening safe external URLs

### Technical Implementation
- New `AboutModal.jsx` component to display app info and links
- Extended `preload.js` with methods to retrieve app version and open external links
- Enhanced `main.js` with IPC handlers for version information and URL validation
- Updated App.jsx to include version display and integrate the About modal
- Added styling for version tag and modal layout

### Screenshots
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/76c83d5b-7d56-4c53-8b75-7192320abdc6" />

### Testing
- [x] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux
- [x] Verified all links open correctly in default browser
- [x] Confirmed version number displays properly