### PR TITLE
Ensure 'Hide window on startup' works across all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Access app settings by clicking the menu button in the top-right corner:
 
 #### 🎨 Appearance
 - **Show Dock icon** (macOS): Choose whether to show the app in the dock
-- **Show Status Bar icon**: Choose whether to show the app in the system tray/menu bar
+- **Show tray icon**: Choose whether to show the app in the system tray/menu bar
 
 ### 📁 Adding a File Source
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -342,7 +342,7 @@ The SourceContext provider is the central state management solution:
    - Enable/disable "Launch at login" and verify behavior on restart
    - Enable/disable "Hide window on startup" and verify behavior
    - Enable/disable "Show Dock icon" (macOS) and verify appearance
-   - Enable/disable "Show Status Bar icon" and verify tray appearance
+   - Enable/disable "Show tray icon" and verify tray appearance
 
 ### 🌐 Test Endpoints
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "open-headers-app",
-  "version": "2.3.2",
+  "name": "open-headers",
+  "version": "2.3.3",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -16,7 +16,9 @@
     "dist:mac": "npm run webpack && electron-builder --mac",
     "dist:linux": "npm run webpack && electron-builder --linux --x64 --arm64",
     "dist:linux:deb": "npm run webpack && electron-builder --linux --x64 --arm64 --config.linux.target=deb",
-    "dist:all": "npm run webpack && electron-builder -mwl --x64 --arm64 --config.linux.target=AppImage"
+    "dist:linux:deb:x64": "npm run webpack && electron-builder --linux --x64 --config.linux.target=deb",
+    "dist:linux:deb:arm64": "npm run webpack && electron-builder --linux --arm64 --config.linux.target=deb",
+    "dist:all": "npm run webpack && electron-builder -mwl --x64 --arm64"
   },
   "build": {
     "appId": "io.openheaders",
@@ -57,7 +59,7 @@
     "removePackageScripts": true,
     "win": {
       "target": "nsis",
-      "artifactName": "${productName}-${version}.${ext}",
+      "artifactName": "${productName}-${version}-Setup.${ext}",
       "icon": "build/icon.ico"
     },
     "mac": {
@@ -74,14 +76,14 @@
           "x64",
           "arm64"
         ]
-      }
+      },
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}"
     },
     "linux": {
       "target": ["deb", "AppImage"],
       "icon": "build/icon.png",
       "category": "Utility;Development;Network",
       "executableName": "open-headers",
-      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "maintainer": "Daniel Tirzuman <github@tirzuman.com>",
       "desktop": {
         "Name": "Open-Headers",
@@ -113,13 +115,26 @@
         "--deb-recommends=libatspi2.0-0",
         "--deb-recommends=libuuid1",
         "--deb-recommends=libsecret-1-0"
-      ]
+      ],
+      "artifactName": "${name}_${version}_${arch}.${ext}",
+      "compression": "xz",
+      "priority": "optional"
+    },
+    "appImage": {
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "desktop": {
+        "Name": "Open Headers",
+        "Comment": "Dynamic sources for Open Headers browser extension",
+        "Categories": "Utility;Development;Network"
+      }
     },
     "nsis": {
       "oneClick": true,
-      "perMachine": false
+      "perMachine": false,
+      "artifactName": "${productName}-${version}-Setup.${ext}"
     },
     "dmg": {
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}",
       "contents": [
         {
           "x": 130,

--- a/src/renderer/components/SettingsModal.jsx
+++ b/src/renderer/components/SettingsModal.jsx
@@ -74,7 +74,7 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
                     name="showStatusBarIcon"
                     valuePropName="checked"
                 >
-                    <Checkbox>Show Status Bar icon</Checkbox>
+                    <Checkbox>Show tray icon</Checkbox>
                 </Form.Item>
             </Form>
         </Modal>


### PR DESCRIPTION
## Overview
This MR fixes the "Hide window on startup" functionality, ensuring it works consistently across Windows, macOS, and Ubuntu. The main issue was that Windows and Ubuntu were not properly detecting auto-launch scenarios or respecting the hidden window state at startup.

## Changes
- Made BrowserWindow always start with `show: false` to ensure proper control of initial visibility
- Enhanced auto-launch detection logic for Windows and Linux
- Added file-based logging to facilitate debugging
- Improved handling of boolean settings to prevent type-related issues
- Standardized distribution package naming across platforms
- Added additional command-line arguments for better auto-launch detection

## Testing
The changes have been verified on all three supported platforms:
- Windows 10/11
- macOS (Intel and Apple Silicon)
- Ubuntu Linux (x64 and ARM64)

The app now correctly remains hidden at system startup when the setting is enabled.

## Fixes
Resolves the issue where the "Hide window on startup" setting didn't work on Windows and Ubuntu.