### PR TITLE
Fix macOS auto-update signature validation issues

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -13,16 +13,16 @@
     "build": "electron-builder --dir",
     "dist": "npm run webpack && electron-builder",
     "dist:win": "npm run webpack && electron-builder --win",
-    "dist:mac": "npm run webpack && electron-builder --mac",
+    "dist:mac": "npm run webpack && electron-builder --mac --x64 --arm64",
     "dist:linux": "npm run webpack && electron-builder --linux --x64 --arm64",
     "dist:linux:deb": "npm run webpack && electron-builder --linux --x64 --arm64 --config.linux.target=deb",
     "dist:linux:deb:x64": "npm run webpack && electron-builder --linux --x64 --config.linux.target=deb",
     "dist:linux:deb:arm64": "npm run webpack && electron-builder --linux --arm64 --config.linux.target=deb",
     "dist:all": "npm run webpack && electron-builder -mwl --x64 --arm64",
-    "publish:mac": "electron-builder --mac --publish always",
+    "publish:mac": "electron-builder --mac --x64 --arm64 --publish always",
     "publish:win": "electron-builder --win --publish always",
     "publish:linux": "electron-builder --linux --publish always",
-    "publish:all": "electron-builder -mwl --publish always"
+    "publish:all": "electron-builder -mwl --x64 --arm64 --publish always"
   },
   "build": {
     "appId": "io.openheaders",
@@ -48,15 +48,13 @@
       },
       {
         "from": "src/renderer/images",
-        "to": "app.asar.unpacked/src/renderer/images",
+        "to": "build/images",
         "filter": [
           "*.png"
         ]
       }
     ],
-    "asarUnpack": [
-      "src/renderer/images/**/*"
-    ],
+    "asarUnpack": [],
     "npmRebuild": false,
     "nodeGypRebuild": false,
     "extends": null,
@@ -69,6 +67,10 @@
     "mac": {
       "category": "public.app-category.utilities",
       "icon": "build/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
         "CFBundleDisplayName": "Open Headers - Dynamic Sources",
         "CFBundleName": "OpenHeaders",


### PR DESCRIPTION
## Auto-Update Fix for macOS

This MR addresses a critical issue with the auto-update process on macOS where signature validation fails with the error: "code has no resources but signature indicates they must be present".

### Changes:
- Properly configured resource bundling to ensure all assets are included in the signature
- Added proper entitlements for hardened runtime on macOS
- Removed asarUnpack configuration which was causing signature verification issues
- Set hardened runtime to true by default for all macOS builds
- Added entitlements file with necessary permissions for Electron
- Updated version to 2.4.4

### Testing:
- Tested auto-update flow from 2.4.1/2.4.3 to 2.4.4 on macOS
- Verified that signature validation passes during update process

This fix ensures that app resources are properly included in the signed application bundle, eliminating the signature validation errors during the update process.