### PR TITLE
Grant content write permissions for GitHub release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write  # This allows creating releases
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Fix for GitHub Release Creation in CI

This PR resolves the issue where GitHub Actions workflow fails to create releases 
when tags are pushed.