### PR TITLE
fix: prevent duplicate artifact uploads in CI release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
       # Build for macOS
       - name: Build macOS
         if: matrix.os == 'macos-latest'
-        run: npm run dist:mac
+        run: npm run dist:mac:skip-publish
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -113,14 +113,14 @@ jobs:
       # Build for Windows
       - name: Build Windows
         if: matrix.os == 'windows-latest'
-        run: npm run dist:win
+        run: npm run dist:win:skip-publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Build for Linux
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
-        run: npm run dist:linux:deb
+        run: npm run dist:linux:skip-publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -13,9 +13,12 @@
     "build": "cross-env NODE_ENV=production electron-builder --dir",
     "dist": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder",
     "dist:win": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --win",
+    "dist:win:skip-publish": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --win --publish never",
     "dist:mac": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --mac",
+    "dist:mac:skip-publish": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --mac --publish never",
     "dist:mac:skip-notarize": "cross-env NODE_ENV=production SKIP_NOTARIZATION=true npm run webpack && cross-env SKIP_NOTARIZATION=true electron-builder --mac",
     "dist:linux": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64",
+    "dist:linux:skip-publish": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --publish never",
     "dist:linux:deb": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb",
     "dist:linux:deb:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=deb",
     "dist:linux:deb:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=deb",


### PR DESCRIPTION
## Fix for Duplicate Release Asset Uploads (v2.4.13)

### Problem
The current CI workflow resulted in duplicate uploads of release assets:
1. Platform-specific build jobs were automatically publishing assets to GitHub releases when run on tagged commits
2. The separate release job was downloading those same assets and re-uploading them
3. This was causing errors with the GitHub API when trying to update existing assets

### Solution
This PR implements a cleaner release workflow:
- Added new npm scripts with `--publish never` flag to prevent automatic publishing during build
- Modified GitHub Actions workflow to use these non-publishing scripts
- Maintained the consolidated release job that handles all release creation and asset uploads

With this fix, the workflow is more efficient:
1. Platform jobs only build the assets and store them as action artifacts
2. Release job creates the GitHub release and uploads all assets in a single operation
3. No more API errors from trying to update existing assets

The changes maintain all existing functionality while eliminating redundant operations.