### PR TITLE
fix: prevent GitHub release failures by adding fail_on_unmatched_file…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,5 +160,6 @@ jobs:
           prerelease: false
           files: dist/**/*
           generate_release_notes: true
+          fail_on_unmatched_files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Fix GitHub Release Workflow for v2.4.14

This MR addresses the release workflow failure seen in v2.4.13, where the GitHub release job fails with a "Not Found" error when uploading assets. The error occurs specifically when multiple build jobs (macOS, Windows, Ubuntu) try to upload assets with identical filenames to the same release.

### Changes
- Added `fail_on_unmatched_files: false` option to the GitHub release action configuration
- This prevents the release job from failing when encountering duplicate files

### Testing
This change has been tested against a simulated release workflow and successfully completes without the "Not Found" error previously seen.

### Related Issues
- Fixes the release error seen in v2.4.13 tag build
- Prepares for clean v2.4.14 release