### PR TITLE
Fix GitHub release workflow by deduplicating artifact uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Organize artifacts into platform-specific directories to prevent conflicts
+      # without renaming files needed for electron-updater
+      - name: Organize artifacts
+        run: |
+          # Create platform-specific subdirectory
+          mkdir -p dist/${{ matrix.os }}
+          
+          # Move files to platform-specific directories to avoid conflicts during download
+          # This preserves original filenames required by electron-updater
+          find dist -type f -name "*.yml" -o -name "*.dmg" -o -name "*.exe" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" | while read file; do
+            filename=$(basename "$file")
+            # Only copy files, don't move, to avoid breaking electron-builder paths
+            cp "$file" "dist/${{ matrix.os }}/$filename"
+          done
+        shell: bash
+
       # Upload artifacts
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -136,6 +152,8 @@ jobs:
             dist/*.AppImage
             dist/*.deb
             dist/*.yml
+            dist/*-latest*.yml
+            dist/*-builder-debug.yml
             dist/latest*
 
   release:
@@ -152,14 +170,63 @@ jobs:
         with:
           path: dist
 
+      # Process and deduplicate artifacts before release
+      - name: Process artifacts for release
+        run: |
+          # Create a temporary directory for processed files
+          mkdir -p processed_files
+          
+          # Track files we've seen to avoid duplicates
+          declare -A seen_files
+          
+          # Process the artifacts in a specific order to ensure correct files are used
+          # Windows files first (for latest.yml)
+          if [ -d "dist/windows-latest-artifacts" ]; then
+            cp dist/windows-latest-artifacts/*.exe processed_files/
+            if [ -f "dist/windows-latest-artifacts/latest.yml" ]; then
+              cp dist/windows-latest-artifacts/latest.yml processed_files/
+              seen_files["latest.yml"]=1
+            fi
+          fi
+          
+          # Mac files second
+          if [ -d "dist/macos-latest-artifacts" ]; then
+            cp dist/macos-latest-artifacts/*.dmg processed_files/
+            cp dist/macos-latest-artifacts/*.zip processed_files/
+            if [ -f "dist/macos-latest-artifacts/latest-mac.yml" ]; then
+              cp dist/macos-latest-artifacts/latest-mac.yml processed_files/
+              seen_files["latest-mac.yml"]=1
+            fi
+          fi
+          
+          # Linux files last
+          if [ -d "dist/ubuntu-latest-artifacts" ]; then
+            cp dist/ubuntu-latest-artifacts/*.AppImage processed_files/
+            cp dist/ubuntu-latest-artifacts/*.deb processed_files/
+            if [ -f "dist/ubuntu-latest-artifacts/latest-linux.yml" ] && [ -z "${seen_files[latest-linux.yml]}" ]; then
+              cp dist/ubuntu-latest-artifacts/latest-linux.yml processed_files/
+              seen_files["latest-linux.yml"]=1
+            fi
+            if [ -f "dist/ubuntu-latest-artifacts/latest-linux-arm64.yml" ] && [ -z "${seen_files[latest-linux-arm64.yml]}" ]; then
+              cp dist/ubuntu-latest-artifacts/latest-linux-arm64.yml processed_files/
+              seen_files["latest-linux-arm64.yml"]=1
+            fi
+          fi
+          
+          # List processed files
+          echo "Files prepared for release:"
+          ls -la processed_files/
+        shell: bash
+
+      # Create release using processed files
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: false
-          files: dist/**/*
-          generate_release_notes: true
+          files: processed_files/*
           fail_on_unmatched_files: false
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Issue
The GitHub Actions release workflow fails with "Not Found" errors when attempting 
to upload multiple files with the same name to a release. This happens because 
the macOS, Windows, and Linux build jobs all generate some files with identical 
names (e.g., builder-debug.yml) that conflict during upload.

## Solution
This MR fixes the issue by:
1. Organizing build artifacts into platform-specific directories
2. Adding a processing step that deduplicates files before release creation
3. Implementing a priority order (Windows → macOS → Linux) to ensure consistent handling
4. Preserving original filenames required by electron-updater for auto-updates

## Testing
- Verified that all required files are properly included in the release
- Confirmed the correct structure of update files for electron-updater
- Ensured all platform-specific binaries are properly uploaded