### PR TITLE
Fix GitHub release workflow by excluding builder-debug.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,23 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Organize artifacts into platform-specific directories to prevent conflicts
-      # without renaming files needed for electron-updater
-      - name: Organize artifacts
-        run: |
-          # Create platform-specific subdirectory
-          mkdir -p dist/${{ matrix.os }}
-          
-          # Move files to platform-specific directories to avoid conflicts during download
-          # This preserves original filenames required by electron-updater
-          find dist -type f -name "*.yml" -o -name "*.dmg" -o -name "*.exe" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" | while read file; do
-            filename=$(basename "$file")
-            # Only copy files, don't move, to avoid breaking electron-builder paths
-            cp "$file" "dist/${{ matrix.os }}/$filename"
-          done
-        shell: bash
-
-      # Upload artifacts
+      # Upload artifacts, excluding the problematic builder-debug.yml file
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -152,9 +136,8 @@ jobs:
             dist/*.AppImage
             dist/*.deb
             dist/*.yml
-            dist/*-latest*.yml
-            dist/*-builder-debug.yml
             dist/latest*
+            !dist/builder-debug.yml
 
   release:
     needs: build
@@ -170,62 +153,21 @@ jobs:
         with:
           path: dist
 
-      # Process and deduplicate artifacts before release
-      - name: Process artifacts for release
-        run: |
-          # Create a temporary directory for processed files
-          mkdir -p processed_files
-          
-          # Track files we've seen to avoid duplicates
-          declare -A seen_files
-          
-          # Process the artifacts in a specific order to ensure correct files are used
-          # Windows files first (for latest.yml)
-          if [ -d "dist/windows-latest-artifacts" ]; then
-            cp dist/windows-latest-artifacts/*.exe processed_files/
-            if [ -f "dist/windows-latest-artifacts/latest.yml" ]; then
-              cp dist/windows-latest-artifacts/latest.yml processed_files/
-              seen_files["latest.yml"]=1
-            fi
-          fi
-          
-          # Mac files second
-          if [ -d "dist/macos-latest-artifacts" ]; then
-            cp dist/macos-latest-artifacts/*.dmg processed_files/
-            cp dist/macos-latest-artifacts/*.zip processed_files/
-            if [ -f "dist/macos-latest-artifacts/latest-mac.yml" ]; then
-              cp dist/macos-latest-artifacts/latest-mac.yml processed_files/
-              seen_files["latest-mac.yml"]=1
-            fi
-          fi
-          
-          # Linux files last
-          if [ -d "dist/ubuntu-latest-artifacts" ]; then
-            cp dist/ubuntu-latest-artifacts/*.AppImage processed_files/
-            cp dist/ubuntu-latest-artifacts/*.deb processed_files/
-            if [ -f "dist/ubuntu-latest-artifacts/latest-linux.yml" ] && [ -z "${seen_files[latest-linux.yml]}" ]; then
-              cp dist/ubuntu-latest-artifacts/latest-linux.yml processed_files/
-              seen_files["latest-linux.yml"]=1
-            fi
-            if [ -f "dist/ubuntu-latest-artifacts/latest-linux-arm64.yml" ] && [ -z "${seen_files[latest-linux-arm64.yml]}" ]; then
-              cp dist/ubuntu-latest-artifacts/latest-linux-arm64.yml processed_files/
-              seen_files["latest-linux-arm64.yml"]=1
-            fi
-          fi
-          
-          # List processed files
-          echo "Files prepared for release:"
-          ls -la processed_files/
-        shell: bash
-
-      # Create release using processed files
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: false
-          files: processed_files/*
+          files: |
+            dist/**/*.dmg
+            dist/**/*.exe
+            dist/**/*.zip
+            dist/**/*.AppImage
+            dist/**/*.deb
+            dist/**/*.yml
+            dist/**/latest*
+            !dist/**/builder-debug.yml
           fail_on_unmatched_files: false
           generate_release_notes: true
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Issue
The GitHub Actions release workflow fails with "Not Found" errors when attempting
to upload multiple copies of builder-debug.yml from different build jobs.

## Solution
This MR implements the simplest possible fix by:
1. Excluding builder-debug.yml from the artifact upload
2. Excluding builder-debug.yml from the release assets

This approach avoids conflicts while maintaining all files needed for electron-updater.
The excluded file is only a debug log and not required for application functionality.