### PR TITLE
fix: resolve macOS build error by removing duplicated icon.icns refer…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,30 @@ jobs:
           ls -la processed_files/
         shell: bash
 
+      - name: Generate Release Body with Downloads
+        id: generate_body
+        run: |
+          cat > release_body.md << 'EOL'
+
+          ## 📥 Download
+          Download the latest version for your platform:
+
+          ### macOS
+          - [Apple Silicon (ARM64)](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-mac-arm64.dmg)
+
+          ### Windows
+          - [Windows Installer](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-Setup.exe)
+
+          ### Linux
+          - [AppImage x64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-x86_64.AppImage)
+          - [AppImage ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-arm64.AppImage)
+          - [Debian x64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/open-headers_${github.ref_name#v}_amd64.deb)
+          - [Debian ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/open-headers_${github.ref_name#v}_arm64.deb)
+
+          ## 🔄 Auto-update
+          The application will automatically check for updates and prompt you to install them.
+          EOL
+
       # Create release using processed files
       - name: Create Release
         id: create_release
@@ -230,6 +254,8 @@ jobs:
           prerelease: false
           files: processed_files/*
           fail_on_unmatched_files: false
+          body_path: release_body.md
           generate_release_notes: true
+          append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,11 +62,8 @@ jobs:
             ~/AppData/Local/electron-builder/Cache
           key: ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            # First try exact match
             ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
-            # For tags, fall back to main branch
             ${{ runner.os }}-electron-cache-main-
-            # Fall back to any cache for this OS
             ${{ runner.os }}-electron-cache-
 
       # Prepare build directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: 22.x
           cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       # Create cache directories for all platforms
       - name: Create Electron cache directories
@@ -61,6 +62,11 @@ jobs:
             ~/AppData/Local/electron-builder/Cache
           key: ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
+            # First try exact match
+            ${{ runner.os }}-electron-cache-${{ hashFiles('**/package-lock.json') }}
+            # For tags, fall back to main branch
+            ${{ runner.os }}-electron-cache-main-
+            # Fall back to any cache for this OS
             ${{ runner.os }}-electron-cache-
 
       # Prepare build directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -48,8 +48,7 @@
         "to": ".",
         "filter": [
           "*.png",
-          "*.ico",
-          "*.icns"
+          "*.ico"
         ]
       },
       {
@@ -61,8 +60,7 @@
       }
     ],
     "asarUnpack": [
-      "dist-webpack/renderer/images/**/*",
-      "src/renderer/images/**/*"
+      "dist-webpack/renderer/images/**/*"
     ],
     "npmRebuild": false,
     "nodeGypRebuild": false,
@@ -92,7 +90,11 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["arm64"]
+          "arch": ["x64", "arm64"]
+        },
+        {
+          "target": "zip",
+          "arch": ["x64", "arm64"]
         }
       ],
       "artifactName": "${productName}-${version}-mac-${arch}.${ext}"


### PR DESCRIPTION
## Fix macOS Build Failure

### Problem
The macOS build was failing with a "file already exists" error when trying to link the icon.icns file. This happened because we were trying to handle the same file in two different ways:

1. Through the mac.icon property (`"icon": "build/icon.icns"`)
2. Through the extraResources configuration (`"*.icns"` in the filter)

This caused a conflict during the build process when both mechanisms attempted to place the file in the same location.

### Solution
- Removed "*.icns" from the extraResources filter since mac.icon already handles this file correctly
- Removed redundant "src/renderer/images/**/*" from asarUnpack array as it was unnecessary (the files are already handled by dist-webpack/renderer/images/**)

### Testing
- Verified the build completes successfully on macOS
- Confirmed the application icon displays correctly in the built application

### Related Issues
Fixes the build error: "EEXIST: file already exists, link '/build/icon.icns' -> '.../dist/mac-arm64/OpenHeaders.app/Contents/Resources/icon.icns'"