### PR TITLE
ci: fix download links in release description template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,26 +224,24 @@ jobs:
       - name: Generate Release Body with Downloads
         id: generate_body
         run: |
-          cat > release_body.md << 'EOL'
-
+          VERSION=${GITHUB_REF_NAME/v/}
+          cat > release_body.md << EOF
           ## 📥 Download
           Download the latest version for your platform:
 
           ### macOS
-          - [Apple Silicon (ARM64)](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-mac-arm64.dmg)
+          - [Intel (x64)](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-mac-x64.dmg)
+          - [Apple Silicon (ARM64)](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-mac-arm64.dmg)
 
           ### Windows
-          - [Windows Installer](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-Setup.exe)
+          - [Windows Installer](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-Setup.exe)
 
           ### Linux
-          - [AppImage x64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-x86_64.AppImage)
-          - [AppImage ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/OpenHeaders-${github.ref_name#v}-arm64.AppImage)
-          - [Debian x64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/open-headers_${github.ref_name#v}_amd64.deb)
-          - [Debian ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/${{ github.ref_name }}/open-headers_${github.ref_name#v}_arm64.deb)
-
-          ## 🔄 Auto-update
-          The application will automatically check for updates and prompt you to install them.
-          EOL
+          - [AppImage x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-x86_64.AppImage)
+          - [AppImage ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-arm64.AppImage)
+          - [Debian x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_amd64.deb)
+          - [Debian ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_arm64.deb)
+          EOF
 
       # Create release using processed files
       - name: Create Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Fix Download Links in Release Description

### Problem
The automatic release description template was showing raw template variables instead of the actual version numbers in download links. For example, instead of showing the correct version in the URL, it displayed:

[Apple Silicon (ARM64)](https://github.com/OpenHeaders/open-headers-app/releases/download/v2.4.18/OpenHeaders-${github.ref_name#v}-mac-arm64.dmg)

This happened because the shell parameter expansion wasn't being processed correctly inside the single-quoted heredoc.

### Solution
This MR fixes the release description generation by:
- Using the `GITHUB_REF_NAME` environment variable directly
- Processing the version number using standard bash parameter substitution
- Using an unquoted heredoc with `EOF` that allows variable expansion

### Result
The download links now properly show the correct version numbers in the release description:

[Apple Silicon (ARM64)](https://github.com/OpenHeaders/open-headers-app/releases/download/v2.4.18/OpenHeaders-2.4.18-mac-arm64.dmg)

This makes it easier for users to find and download the appropriate version for their platform.