### PR TITLE
fix: ensure update notification sequence shows properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.20",
+  "version": "2.4.21",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
## Fix Update Notification Display Sequence

### Problem
When users manually check for updates, there's a race condition between the "update-not-available" and "clear-update-checking-notification" events from the main process. This causes the "Checking for Updates" notification to disappear without showing the "No Updates Available" follow-up notification, creating a confusing user experience.

### Changes
- Added `pendingNotificationRef` to track when a delayed notification is scheduled
- Updated `handleUpdateNotAvailable` to properly manage state during notification transitions
- Modified `handleClearCheckingNotification` to respect pending notifications
- Added detailed debug logging to track notification state changes

### Testing Done
- Manually tested update checks on macOS with debug logging enabled
- Verified the proper notification sequence:
  1. "Checking for Updates" notification displays for ~2 seconds
  2. "No Updates Available" notification displays for ~4 seconds
- Confirmed the notification transition is smooth with no flickering

### Affected Components
- `UpdateNotification.jsx`: The main component handling update notifications

This fix ensures our users get proper feedback when manually checking for updates, improving the overall UX of the application.

Ready for release in version 2.4.21.