### PR TITLE
ui: enhance settings modal with macOS-style design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/renderer/components/SettingsModal.jsx
+++ b/src/renderer/components/SettingsModal.jsx
@@ -1,23 +1,49 @@
-import React from 'react';
-import { Modal, Form, Checkbox, Divider, Button, Space } from 'antd';
+import React, { useState, useEffect } from 'react';
+import { Modal, Form, Switch, Divider, Button, Row, Col, Typography, Space, Tooltip } from 'antd';
+import {
+    LoginOutlined,
+    EyeInvisibleOutlined,
+    AppstoreOutlined,
+    MenuOutlined
+} from '@ant-design/icons';
+
+const { Text } = Typography;
 
 /**
- * SettingsModal component for application settings
+ * SettingsModal component styled to closely match macOS system preferences
+ * with proper state-dependent styling and functionality
  */
 const SettingsModal = ({ open, settings, onCancel, onSave }) => {
     const [form] = Form.useForm();
+    const [formValues, setFormValues] = useState(settings || {});
 
     // When settings or visibility change, update form values
-    React.useEffect(() => {
+    useEffect(() => {
         if (open && settings) {
             form.setFieldsValue(settings);
+            setFormValues(settings);
         }
     }, [open, settings, form]);
+
+    // Track form value changes and enforce dependencies
+    const handleValuesChange = (changedValues, allValues) => {
+        // If "Open at login" is turned off, also disable "Hide on start"
+        if (changedValues.hasOwnProperty('launchAtLogin') && !changedValues.launchAtLogin) {
+            form.setFieldValue('hideOnLaunch', false);
+            allValues.hideOnLaunch = false;
+        }
+
+        setFormValues(allValues);
+    };
 
     // Handle form submission
     const handleSubmit = () => {
         form.validateFields()
             .then(values => {
+                // Enforce dependency rule: if launchAtLogin is false, hideOnLaunch must be false
+                if (!values.launchAtLogin) {
+                    values.hideOnLaunch = false;
+                }
                 onSave(values);
             })
             .catch(info => {
@@ -25,11 +51,63 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
             });
     };
 
+    // Section title style
+    const sectionStyle = {
+        fontSize: 13,
+        fontWeight: 600,
+        color: '#1d1d1f',
+        marginBottom: 16,
+        marginTop: 8,
+    };
+
+    // Get option state style based on toggle value
+    const getOptionStyle = (isActive) => {
+        return {
+            marginBottom: 20,
+            transition: 'opacity 0.2s ease',
+            opacity: isActive ? 1 : 0.6,
+        };
+    };
+
+    // Get label style based on toggle state
+    const getLabelStyle = (isActive) => {
+        return {
+            fontWeight: 500,
+            display: 'flex',
+            alignItems: 'center',
+            transition: 'color 0.2s ease',
+            color: isActive ? '#1d1d1f' : '#86868b',
+        };
+    };
+
+    // Get icon style based on toggle state
+    const getIconStyle = (isActive) => {
+        return {
+            marginRight: 8,
+            color: isActive ? '#0071e3' : '#86868b',
+            transition: 'color 0.2s ease',
+        };
+    };
+
+    // Description style with conditional opacity
+    const getDescStyle = (isActive) => {
+        return {
+            fontSize: 12,
+            color: isActive ? 'rgba(0, 0, 0, 0.45)' : 'rgba(0, 0, 0, 0.3)',
+            marginTop: 4,
+            transition: 'color 0.2s ease',
+        };
+    };
+
+    // Calculate dependent option states
+    const canHideOnLaunch = formValues.launchAtLogin;
+
     return (
         <Modal
-            title="Application Settings"
+            title="Settings"
             open={open}
             onCancel={onCancel}
+            width={500}
             footer={[
                 <Button key="cancel" onClick={onCancel}>
                     Cancel
@@ -38,6 +116,11 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
                     Save
                 </Button>
             ]}
+            centered
+            bodyStyle={{
+                padding: '20px 24px',
+                fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif'
+            }}
         >
             <Form
                 form={form}
@@ -48,34 +131,84 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
                     showDockIcon: true,
                     showStatusBarIcon: true
                 }}
+                onValuesChange={handleValuesChange}
+                style={{ fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Arial, sans-serif' }}
             >
-                <Divider orientation="left">Startup Options</Divider>
-                <Form.Item
-                    name="launchAtLogin"
-                    valuePropName="checked"
-                >
-                    <Checkbox>Launch at login</Checkbox>
-                </Form.Item>
-                <Form.Item
-                    name="hideOnLaunch"
-                    valuePropName="checked"
-                >
-                    <Checkbox>Hide window on startup</Checkbox>
-                </Form.Item>
+                <div style={sectionStyle}>General</div>
 
-                <Divider orientation="left">Appearance</Divider>
-                <Form.Item
-                    name="showDockIcon"
-                    valuePropName="checked"
-                >
-                    <Checkbox>Show Dock icon (macOS only)</Checkbox>
-                </Form.Item>
-                <Form.Item
-                    name="showStatusBarIcon"
-                    valuePropName="checked"
-                >
-                    <Checkbox>Show tray icon</Checkbox>
-                </Form.Item>
+                <Row style={getOptionStyle(true)} align="middle" justify="space-between">
+                    <Col span={16}>
+                        <div style={getLabelStyle(formValues.launchAtLogin)}>
+                            <LoginOutlined style={getIconStyle(formValues.launchAtLogin)} />
+                            <Space direction="vertical" size={0}>
+                                <span>Open at login</span>
+                                <span style={getDescStyle(formValues.launchAtLogin)}>Start automatically when you log in</span>
+                            </Space>
+                        </div>
+                    </Col>
+                    <Col span={8} style={{ textAlign: 'right' }}>
+                        <Form.Item name="launchAtLogin" valuePropName="checked" noStyle>
+                            <Switch />
+                        </Form.Item>
+                    </Col>
+                </Row>
+
+                <Tooltip title={!canHideOnLaunch ? "Enable 'Open at login' to use this option" : ""}>
+                    <Row style={getOptionStyle(canHideOnLaunch)} align="middle" justify="space-between">
+                        <Col span={16}>
+                            <div style={getLabelStyle(canHideOnLaunch && formValues.hideOnLaunch)}>
+                                <EyeInvisibleOutlined style={getIconStyle(canHideOnLaunch && formValues.hideOnLaunch)} />
+                                <Space direction="vertical" size={0}>
+                                    <span>Hide on start</span>
+                                    <span style={getDescStyle(canHideOnLaunch && formValues.hideOnLaunch)}>Start in background mode</span>
+                                </Space>
+                            </div>
+                        </Col>
+                        <Col span={8} style={{ textAlign: 'right' }}>
+                            <Form.Item name="hideOnLaunch" valuePropName="checked" noStyle>
+                                <Switch disabled={!canHideOnLaunch} />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Tooltip>
+
+                <Divider style={{ margin: '8px 0 16px 0' }} />
+
+                <div style={sectionStyle}>Appearance</div>
+
+                <Row style={getOptionStyle(true)} align="middle" justify="space-between">
+                    <Col span={16}>
+                        <div style={getLabelStyle(formValues.showDockIcon)}>
+                            <AppstoreOutlined style={getIconStyle(formValues.showDockIcon)} />
+                            <Space direction="vertical" size={0}>
+                                <span>Show in Dock</span>
+                                <span style={getDescStyle(formValues.showDockIcon)}>Display app icon in the Dock</span>
+                            </Space>
+                        </div>
+                    </Col>
+                    <Col span={8} style={{ textAlign: 'right' }}>
+                        <Form.Item name="showDockIcon" valuePropName="checked" noStyle>
+                            <Switch />
+                        </Form.Item>
+                    </Col>
+                </Row>
+
+                <Row style={getOptionStyle(true)} align="middle" justify="space-between">
+                    <Col span={16}>
+                        <div style={getLabelStyle(formValues.showStatusBarIcon)}>
+                            <MenuOutlined style={getIconStyle(formValues.showStatusBarIcon)} />
+                            <Space direction="vertical" size={0}>
+                                <span>Show in menu bar</span>
+                                <span style={getDescStyle(formValues.showStatusBarIcon)}>Display app icon in the menu bar</span>
+                            </Space>
+                        </div>
+                    </Col>
+                    <Col span={8} style={{ textAlign: 'right' }}>
+                        <Form.Item name="showStatusBarIcon" valuePropName="checked" noStyle>
+                            <Switch />
+                        </Form.Item>
+                    </Col>
+                </Row>
             </Form>
         </Modal>
     );


### PR DESCRIPTION
## Enhanced Settings Modal with macOS-Style Design

This MR transforms the settings modal to provide a true macOS-like experience, improving both the visual presentation and functional behavior of the settings.

### Changes

- **Visual Overhaul:**
  - Replaced checkboxes with switches for a more modern macOS look
  - Added colored icons for each setting
  - Implemented proper SF Pro Typography
  - Created left-aligned labels with right-aligned controls
  - Added detailed descriptions for each option
  - Used proper macOS color palette (#0071e3 primary blue, #86868b for disabled text)

- **Behavioral Improvements:**
  - Added dynamic styling based on toggle state (reduced opacity when off)
  - Implemented proper option dependencies ("Hide on start" requires "Open at login")
  - Added tooltips to explain why options are disabled
  - Automatic resetting of dependent options when parent options are disabled

- **Text Improvements:**
  - Updated option labels to match macOS terminology:
    - "Open at login" instead of "Launch at login"
    - "Hide on start" instead of "Hide window on startup" 
    - "Show in Dock" instead of "Show Dock icon"
    - "Show in menu bar" instead of "Show tray icon"
  - Added concise, descriptive text for each option

### Screenshots

<img width="704" alt="image" src="https://github.com/user-attachments/assets/068c73ae-e69f-4714-bdc2-c077b67c3901" />

### Testing Done

- Verified all options save properly
- Tested dependency logic between "Open at login" and "Hide on start"
- Verified visual state changes when options are toggled
- Confirmed tooltip appears when hovering over disabled option
- Tested on macOS to ensure it matches system design language

This change provides a more professional, coherent settings experience that will feel familiar to macOS users and is ready for inclusion in the 2.4.22 release.