### PR TITLE
platform: restrict RPM builds to Linux CI environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,12 @@ jobs:
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 
-      # Install RPM build dependencies on Linux runner ONLY
-      - name: Install RPM build tools (Linux)
+      # Install RPM tools on Linux runner only (using correct package name for Ubuntu)
+      - name: Install RPM tools (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm librpm-dev rpm-build
+          sudo apt-get install -y rpm librpm-dev
           echo "::debug::Installed RPM build tools"
           rpm --version
 
@@ -129,7 +129,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build for Linux
+      # Build for Linux (including RPM packages)
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,15 @@ jobs:
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 
+      # Install RPM build dependencies on Linux runner ONLY
+      - name: Install RPM build tools (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm librpm-dev rpm-build
+          echo "::debug::Installed RPM build tools"
+          rpm --version
+
       # Create cache directories for all platforms
       - name: Create Electron cache directories
         shell: bash
@@ -102,7 +111,7 @@ jobs:
           mkdir -p dist
         shell: bash
 
-      # Build for macOS
+      # Build for macOS - skip RPM builds on macOS
       - name: Build macOS
         if: matrix.os == 'macos-latest'
         run: npm run dist:mac:skip-publish
@@ -123,7 +132,25 @@ jobs:
       # Build for Linux
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
-        run: npm run dist:linux:skip-publish
+        run: |
+          # Build all Linux targets (including RPM)
+          npm run dist:linux:skip-publish
+          
+          # Verify RPM packages were built successfully
+          if [ $(find dist -name "*.rpm" -type f | wc -l) -eq 0 ]; then
+            echo "::warning::RPM packages not found in regular build, trying explicit RPM build..."
+            npm run dist:linux:rpm:x64
+            npm run dist:linux:rpm:arm64
+          
+            # Check again after explicit build attempt
+            if [ $(find dist -name "*.rpm" -type f | wc -l) -eq 0 ]; then
+              echo "::error::Failed to build RPM packages even with explicit build"
+              exit 1
+            fi
+          else
+            echo "RPM packages successfully built in main Linux build:"
+            find dist -name "*.rpm" -type f | xargs ls -la
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -136,7 +163,7 @@ jobs:
           
           # Move files to platform-specific directories to avoid conflicts during download
           # This preserves original filenames required by electron-updater
-          find dist -type f -name "*.yml" -o -name "*.dmg" -o -name "*.exe" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" | while read file; do
+          find dist -type f -name "*.yml" -o -name "*.dmg" -o -name "*.exe" -o -name "*.zip" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" | while read file; do
             filename=$(basename "$file")
             # Only copy files, don't move, to avoid breaking electron-builder paths
             cp "$file" "dist/${{ matrix.os }}/$filename"
@@ -154,6 +181,7 @@ jobs:
             dist/*.zip
             dist/*.AppImage
             dist/*.deb
+            dist/*.rpm
             dist/*.yml
             dist/*-latest*.yml
             dist/*-builder-debug.yml
@@ -202,10 +230,26 @@ jobs:
             fi
           fi
           
-          # Linux files last
+          # Linux files last (RPM files come from Ubuntu runner only)
           if [ -d "dist/ubuntu-latest-artifacts" ]; then
             cp dist/ubuntu-latest-artifacts/*.AppImage processed_files/
             cp dist/ubuntu-latest-artifacts/*.deb processed_files/
+          
+            # Explicitly copy RPM files - ensure they exist
+            echo "Copying RPM files to processed_files"
+            find dist/ubuntu-latest-artifacts -name "*.rpm" -exec cp {} processed_files/ \;
+          
+            # Check if RPM files were copied
+            RPM_COUNT=$(find processed_files -name "*.rpm" | wc -l)
+            echo "Found $RPM_COUNT RPM files in processed_files directory"
+          
+            # Fail if no RPM files found
+            if [ $RPM_COUNT -eq 0 ]; then
+              echo "::error::No RPM files found in artifacts"
+              exit 1
+            fi
+          
+            # Continue with other files
             if [ -f "dist/ubuntu-latest-artifacts/latest-linux.yml" ] && [ -z "${seen_files[latest-linux.yml]}" ]; then
               cp dist/ubuntu-latest-artifacts/latest-linux.yml processed_files/
               seen_files["latest-linux.yml"]=1
@@ -239,8 +283,10 @@ jobs:
           ### Linux
           - [AppImage x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-x86_64.AppImage)
           - [AppImage ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-arm64.AppImage)
-          - [Debian x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_amd64.deb)
-          - [Debian ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_arm64.deb)
+          - [Debian/Ubuntu x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_amd64.deb)
+          - [Debian/Ubuntu ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_arm64.deb)
+          - [Fedora/RHEL x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers-${VERSION}.x86_64.rpm)
+          - [Fedora/RHEL ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers-${VERSION}.aarch64.rpm)
           EOF
 
       # Create release using processed files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.25",
+  "version": "2.4.26",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -22,6 +22,10 @@
     "dist:linux:deb": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb",
     "dist:linux:deb:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=deb",
     "dist:linux:deb:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=deb",
+    "dist:linux:rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=rpm",
+    "dist:linux:rpm:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=rpm",
+    "dist:linux:rpm:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=rpm",
+    "dist:macos:no-rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb --config.linux.target=AppImage --publish never",
     "dist:all": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder -mwl --x64 --arm64",
     "dist:dev": "cross-env NODE_ENV=development SKIP_NOTARIZATION=true npm run webpack && cross-env SKIP_NOTARIZATION=true electron-builder",
     "publish:mac": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --mac --publish always",
@@ -102,6 +106,7 @@
     "linux": {
       "target": [
         "deb",
+        "rpm",
         "AppImage"
       ],
       "icon": "build/icon.png",
@@ -142,6 +147,27 @@
       "artifactName": "${name}_${version}_${arch}.${ext}",
       "compression": "xz",
       "priority": "optional"
+    },
+    "rpm": {
+      "artifactName": "${name}-${version}.${arch}.rpm",
+      "depends": [
+        "libgtk-3",
+        "libnotify",
+        "nss",
+        "libXScrnSaver",
+        "libXtst",
+        "xdg-utils",
+        "at-spi2-core",
+        "libuuid",
+        "libsecret"
+      ],
+      "fpm": [
+        "--rpm-rpmbuild-define=_build_id_links none",
+        "--rpm-os=linux",
+        "--rpm-rpmbuild-define=_binary_payload w2.xzdio",
+        "--rpm-rpmbuild-define=_binary_filedigest_algorithm 2",
+        "--rpm-rpmbuild-define=_source_filedigest_algorithm 2"
+      ]
     },
     "appImage": {
       "artifactName": "${productName}-${version}-${arch}.${ext}",


### PR DESCRIPTION
Move RPM package building to GitHub Actions workflow on Linux runners only, as macOS lacks native RPM build tools. Add non-RPM Linux build option for macOS development environments.