### PR TITLE
platform: add cross-distribution RPM dependency support

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,9 +166,7 @@
         "--rpm-os=linux",
         "--rpm-rpmbuild-define=_binary_payload w2.xzdio",
         "--rpm-rpmbuild-define=_binary_filedigest_algorithm 2",
-        "--rpm-rpmbuild-define=_source_filedigest_algorithm 2",
-        "--rpm-tag=Provides: open-headers = ${version}",
-        "--rpm-tag=Provides: openheaders = ${version}"
+        "--rpm-rpmbuild-define=_source_filedigest_algorithm 2"
       ]
     },
     "appImage": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dist:linux:rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=rpm",
     "dist:linux:rpm:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=rpm",
     "dist:linux:rpm:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=rpm",
-    "dist:linux:rpm:fedora": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=rpm --config.rpm.depends=\"gtk3,libnotify,nss,libXScrnSaver,libXtst,xdg-utils,at-spi2-atk,libuuid,libsecret\"",
     "dist:macos:no-rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb --config.linux.target=AppImage --publish never",
     "dist:all": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder -mwl --x64 --arm64",
     "dist:dev": "cross-env NODE_ENV=development SKIP_NOTARIZATION=true npm run webpack && cross-env SKIP_NOTARIZATION=true electron-builder",
@@ -152,15 +151,15 @@
     "rpm": {
       "artifactName": "${name}-${version}.${arch}.rpm",
       "depends": [
-        "libgtk-3 >= 3.0.0 | gtk3 >= 3.0.0",
-        "libnotify >= 0.7.0 | libnotify4 >= 0.7.0",
-        "nss >= 3.0.0",
-        "libXScrnSaver | libxss1",
-        "libXtst | libxtst6",
+        "gtk3",
+        "libnotify",
+        "nss",
+        "libXScrnSaver",
+        "libXtst",
         "xdg-utils",
-        "at-spi2-core | at-spi2-atk | libatspi2.0-0",
-        "libuuid | libuuid1",
-        "libsecret | libsecret-1-0"
+        "at-spi2-core",
+        "libuuid",
+        "libsecret"
       ],
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links none",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.26",
+  "version": "2.4.27",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -25,6 +25,7 @@
     "dist:linux:rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=rpm",
     "dist:linux:rpm:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=rpm",
     "dist:linux:rpm:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=rpm",
+    "dist:linux:rpm:fedora": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=rpm --config.rpm.depends=\"gtk3,libnotify,nss,libXScrnSaver,libXtst,xdg-utils,at-spi2-atk,libuuid,libsecret\"",
     "dist:macos:no-rpm": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb --config.linux.target=AppImage --publish never",
     "dist:all": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder -mwl --x64 --arm64",
     "dist:dev": "cross-env NODE_ENV=development SKIP_NOTARIZATION=true npm run webpack && cross-env SKIP_NOTARIZATION=true electron-builder",
@@ -151,22 +152,24 @@
     "rpm": {
       "artifactName": "${name}-${version}.${arch}.rpm",
       "depends": [
-        "libgtk-3",
-        "libnotify",
-        "nss",
-        "libXScrnSaver",
-        "libXtst",
+        "libgtk-3 >= 3.0.0 | gtk3 >= 3.0.0",
+        "libnotify >= 0.7.0 | libnotify4 >= 0.7.0",
+        "nss >= 3.0.0",
+        "libXScrnSaver | libxss1",
+        "libXtst | libxtst6",
         "xdg-utils",
-        "at-spi2-core",
-        "libuuid",
-        "libsecret"
+        "at-spi2-core | at-spi2-atk | libatspi2.0-0",
+        "libuuid | libuuid1",
+        "libsecret | libsecret-1-0"
       ],
       "fpm": [
         "--rpm-rpmbuild-define=_build_id_links none",
         "--rpm-os=linux",
         "--rpm-rpmbuild-define=_binary_payload w2.xzdio",
         "--rpm-rpmbuild-define=_binary_filedigest_algorithm 2",
-        "--rpm-rpmbuild-define=_source_filedigest_algorithm 2"
+        "--rpm-rpmbuild-define=_source_filedigest_algorithm 2",
+        "--rpm-tag=Provides: open-headers = ${version}",
+        "--rpm-tag=Provides: openheaders = ${version}"
       ]
     },
     "appImage": {


### PR DESCRIPTION
Update RPM package configuration to work across multiple Linux distributions by providing alternative dependency names for Debian/Ubuntu and Fedora/RHEL systems. Use the pipe operator to allow package managers to resolve dependencies correctly on different distributions.

- Add alternative package names for all dependencies
- Include minimum version requirements for critical libraries
- Add "Provides" tags for better package identification
- Create a Fedora-specific build script option

Fixes installation errors on Fedora and other RPM-based distributions.