### PR TITLE
fix: add postinstallation script creating symlink in /usr/bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.27",
+  "version": "2.4.28",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -116,7 +116,8 @@
       "desktop": {
         "Name": "OpenHeaders",
         "Comment": "Dynamic sources for Open Headers browser extension",
-        "Terminal": false
+        "Terminal": false,
+        "Categories": "Utility;Development;Network"
       },
       "synopsis": "Manage dynamic sources from files, environment variables, and HTTP endpoints",
       "description": "Companion app for the Open Headers browser extension that manages dynamic sources from files, environment variables, and HTTP endpoints."
@@ -146,7 +147,8 @@
       ],
       "artifactName": "${name}_${version}_${arch}.${ext}",
       "compression": "xz",
-      "priority": "optional"
+      "priority": "optional",
+      "afterInstall": "./scripts/debian/postinst"
     },
     "rpm": {
       "artifactName": "${name}-${version}.${arch}.rpm",

--- a/scripts/debian/postinst
+++ b/scripts/debian/postinst
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Fixes Chrome sandbox permissions and creates necessary symlinks
+
+# Set the correct permissions for the Chrome sandbox
+if [ -e "/opt/OpenHeaders/chrome-sandbox" ]; then
+  chown root:root "/opt/OpenHeaders/chrome-sandbox"
+  chmod 4755 "/opt/OpenHeaders/chrome-sandbox"
+  echo "Chrome sandbox permissions fixed"
+fi
+
+# Create symlink in /usr/bin for command-line access
+if [ -e "/opt/OpenHeaders/open-headers" ] && [ ! -e "/usr/bin/open-headers" ]; then
+  ln -sf "/opt/OpenHeaders/open-headers" "/usr/bin/open-headers"
+  echo "Command-line access enabled: created symlink in /usr/bin"
+fi
+
+# Update desktop database
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database
+fi
+
+exit 0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -238,6 +238,11 @@ const rendererConfig = {
                     from: path.resolve(__dirname, 'config'),
                     to: path.resolve(__dirname, 'dist-webpack/config'),
                     noErrorOnMissing: true
+                },
+                {
+                    from: path.resolve(__dirname, 'scripts/debian'),
+                    to: path.resolve(__dirname, 'dist-webpack/scripts/debian'),
+                    noErrorOnMissing: true
                 }
             ]
         })


### PR DESCRIPTION
This commit adds a new postinstallation script that creates a symlink in /usr/bin pointing to the Open Headers executable. The script ensures that users can run the application from any terminal by simply typing 'open-headers' without specifying the full path.

The script also:
- Sets correct permissions for the Chrome sandbox
- Updates the desktop database for proper menu integration
- Outputs helpful messages to confirm successful installation steps

This enhancement follows standard Linux conventions for command-line applications and significantly improves user experience during first-time installation.