### PR TITLE
fix: Add installation script for Linux AppImage to fix Chrome sandbox perm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,7 @@ jobs:
           if [ -d "dist/ubuntu-latest-artifacts" ]; then
             cp dist/ubuntu-latest-artifacts/*.AppImage processed_files/
             cp dist/ubuntu-latest-artifacts/*.deb processed_files/
+            cp dist/ubuntu-latest-artifacts/install-open-headers.sh processed_files/ 2>/dev/null || echo "Installation script not found"
           
             # Explicitly copy RPM files - ensure they exist
             echo "Copying RPM files to processed_files"

--- a/build/linux/install-open-headers.sh
+++ b/build/linux/install-open-headers.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# OpenHeaders AppImage Installation Script
+# This script follows the exact steps that worked manually
+
+# Exit on any error
+set -e
+
+# Display script header
+echo "=========================================================="
+echo "     OpenHeaders Installation Script"
+echo "=========================================================="
+echo ""
+
+# Check if running as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script requires root privileges to set proper sandbox permissions."
+    echo "Please run with sudo: sudo ./install-open-headers.sh"
+    exit 1
+fi
+
+# Get directory where script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPIMAGE_NAME="OpenHeaders-2.4.28-arm64.AppImage"
+APPIMAGE_PATH="$SCRIPT_DIR/$APPIMAGE_NAME"
+
+# Check if AppImage exists
+if [ ! -f "$APPIMAGE_PATH" ]; then
+    echo "Error: $APPIMAGE_NAME not found in the current directory."
+    echo "Please place this script in the same directory as the AppImage."
+    exit 1
+fi
+
+# Get the current user for permission setting later
+CURRENT_USER=$(logname || echo $SUDO_USER || echo $USER)
+echo "Installing for user: $CURRENT_USER"
+
+echo "Step 1: Making AppImage executable..."
+chmod +x "$APPIMAGE_PATH"
+echo "✓ Done"
+echo ""
+
+echo "Step 2: Extracting AppImage..."
+cd "$SCRIPT_DIR"
+"$APPIMAGE_PATH" --appimage-extract
+echo "✓ Done"
+echo ""
+
+echo "Step 3: Setting sandbox permissions..."
+chown root:root squashfs-root/chrome-sandbox
+chmod 4755 squashfs-root/chrome-sandbox
+echo "✓ Done"
+echo ""
+
+echo "Step 4: Installing to /opt/OpenHeaders..."
+# Remove previous installation if exists
+if [ -d "/opt/OpenHeaders" ]; then
+    rm -rf /opt/OpenHeaders
+fi
+
+# Move the extracted files to /opt
+mv squashfs-root /opt/OpenHeaders
+
+# CRITICAL: Fix directory permissions so user can access it
+chown -R $CURRENT_USER:$CURRENT_USER /opt/OpenHeaders
+# Keep chrome-sandbox with root ownership
+chown root:root /opt/OpenHeaders/chrome-sandbox
+chmod 4755 /opt/OpenHeaders/chrome-sandbox
+echo "✓ Done"
+echo ""
+
+echo "Step 5: Creating command-line access..."
+# Create a wrapper script in /usr/bin which is in PATH
+cat > /usr/bin/open-headers << 'EOF'
+#!/bin/bash
+# Run OpenHeaders and force window to show
+cd /opt/OpenHeaders
+./open-headers "$@"
+EOF
+
+# Make it executable
+chmod +x /usr/bin/open-headers
+echo "✓ Done"
+echo ""
+
+echo "Step 6: Creating desktop shortcut..."
+cat > /usr/share/applications/openheaders.desktop << EOF
+[Desktop Entry]
+Name=OpenHeaders
+Comment=Dynamic sources for Open Headers browser extension
+Exec=/usr/bin/open-headers
+Icon=/opt/OpenHeaders/open-headers.png
+Terminal=false
+Type=Application
+Categories=Utility;Development;Network;
+EOF
+echo "✓ Done"
+echo ""
+
+echo "=========================================================="
+echo "✅ OpenHeaders has been successfully installed!"
+echo "   You can now launch it by:"
+echo ""
+echo "   • Running 'open-headers' from the terminal"
+echo "   • Using the application menu in your desktop environment"
+echo ""
+echo "   If you encounter any issues, try running directly:"
+echo "   $ cd /opt/OpenHeaders && ./open-headers"
+echo "=========================================================="

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "dist:mac:skip-publish": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --mac --publish never",
     "dist:mac:skip-notarize": "cross-env NODE_ENV=production SKIP_NOTARIZATION=true npm run webpack && cross-env SKIP_NOTARIZATION=true electron-builder --mac",
     "dist:linux": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64",
+    "dist:linux:app-image:arm64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --arm64 --config.linux.target=AppImage",
     "dist:linux:skip-publish": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --publish never",
     "dist:linux:deb": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --arm64 --config.linux.target=deb",
     "dist:linux:deb:x64": "cross-env NODE_ENV=production npm run webpack && cross-env electron-builder --linux --x64 --config.linux.target=deb",
@@ -46,6 +47,7 @@
     "asar": true,
     "compression": "maximum",
     "afterSign": "./scripts/notarize.js",
+    "afterPack": "./scripts/afterPackHook.js",
     "extraResources": [
       {
         "from": "build",

--- a/scripts/afterPackHook.js
+++ b/scripts/afterPackHook.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.default = async function(context) {
+    const { appOutDir, electronPlatformName } = context;
+
+    // Only apply for Linux builds
+    if (electronPlatformName !== 'linux') {
+        return;
+    }
+
+    console.log('Running afterPack hook for Linux build...');
+
+    // Path to the source file in dist-webpack
+    const sourceFile = path.join(process.cwd(), 'dist-webpack', 'install-open-headers.sh');
+
+    // Path where we want to copy the file
+    const destDir = path.dirname(appOutDir);
+    const destFile = path.join(destDir, 'install-open-headers.sh');
+
+    try {
+        if (fs.existsSync(sourceFile)) {
+            // Copy the file to the dist directory (alongside the AppImage)
+            fs.copyFileSync(sourceFile, destFile);
+            // Make it executable
+            fs.chmodSync(destFile, 0o755);
+            console.log(`Successfully copied ${sourceFile} to ${destFile}`);
+        } else {
+            console.error(`Source file not found: ${sourceFile}`);
+        }
+    } catch (error) {
+        console.error('Error copying install script:', error);
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -243,6 +243,10 @@ const rendererConfig = {
                     from: path.resolve(__dirname, 'scripts/debian'),
                     to: path.resolve(__dirname, 'dist-webpack/scripts/debian'),
                     noErrorOnMissing: true
+                },
+                {
+                    from: path.resolve(__dirname, 'build/linux/install-open-headers.sh'),
+                    to: path.resolve(__dirname, 'dist-webpack/install-open-headers.sh')
                 }
             ]
         })


### PR DESCRIPTION
This commit adds an installation script (install-open-headers.sh) that properly handles the Chrome sandbox permissions issue on Linux distributions, especially Ubuntu 24.04.

The script:
- Extracts the AppImage contents
- Sets correct ownership and permissions on chrome-sandbox (root:root, 4755)
- Installs the application to /opt/OpenHeaders with proper user permissions
- Creates a command-line launcher and desktop shortcut

This fixes the "SUID sandbox helper binary was found, but is not configured correctly" error and provides a seamless user experience without requiring manual command-line intervention.