### PR TITLE
update: improve Linux .AppImage installation script handling in build…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
             dist/*-latest*.yml
             dist/*-builder-debug.yml
             dist/latest*
+            dist/install-open-headers.sh
 
   release:
     needs: build
@@ -286,9 +287,12 @@ jobs:
           - [AppImage ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/OpenHeaders-$VERSION-arm64.AppImage) (.AppImage for any Linux distro)
           - [Debian/Ubuntu x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_amd64.deb) (.deb for Debian/Ubuntu)
           - [Debian/Ubuntu ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers_${VERSION}_arm64.deb) (.deb for Debian/Ubuntu)
+          
           - [Fedora/RHEL x64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers-${VERSION}.x86_64.rpm) (.rpm for Fedora/RHEL/CentOS)
           - [Fedora/RHEL ARM64](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/open-headers-${VERSION}.aarch64.rpm) (.rpm for Fedora/RHEL/CentOS)
-
+          
+          - [Installation Script](https://github.com/OpenHeaders/open-headers-app/releases/download/$GITHUB_REF_NAME/install-open-headers.sh) (Helper script for Linux .AppImage installation)
+          
           ## 🚀 Installation & Startup
 
           ### Windows

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.4.31",
+  "version": "2.4.32",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
… workflow

Add missing install-open-headers.sh for .AppImage in GitHub releases.