### PR TITLE
fix: auto-refresh functionality for HTTP sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
  This commit addresses several issues with the auto-refresh functionality for HTTP sources:

  1. Fixed race condition in setupRefresh where refreshing state would get stuck
     - Added delay to ensure components are fully mounted before refresh
     - Restructured refresh logic to avoid nested callbacks - Fixed timer cleanup to prevent stale timers

  2. Fixed bug with auto-refreshing HTTP sources with expired timers at app startup - Added proper initialization sequence with timeout safeguards - Improved error handling for refresh operations - Added recovery mechanism for stuck refresh state

  3. Fixed UI getting stuck in 'Refreshing...' state
     - Added timeout detection for slow requests
     - Ensured refresh state is always properly cleared

  4. Fixed refresh timer not resetting after Edit dialog save - Added explicit timer reset logic in handleSaveSource - Enhanced timing preservation logic to properly detect when to reset

  These changes make the auto-refresh functionality more robust and reliable,
  especially during application startup and after source edits.