### PR TITLE
fix: ensure HTTP sources with expired timers refresh immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
  This commit implements a direct refresh execution approach for HTTP sources with expired
  timers. When a source is loaded with an expired timer, it now performs an
  immediate refresh rather than relying on complex timer coordination. This
  prevents sources from getting stuck in "Refreshing..." state and ensures
  consistent refresh behavior.