### PR TITLE
fix: prevent duplicate HTTP requests during refresh operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
  Resolves the issue where HTTP sources would make duplicate requests in two scenarios:
  1. When starting the app with an expired timer
  2. When saving a source in the Edit Modal with "Refresh immediately" enabled

  The solution sets skipImmediateRefresh flag appropriately to ensure only one
  refresh operation happens at a time, while maintaining proper refresh timing.