### PR TITLE
fix: Fix HTTP source timer updating when changing refresh interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
  When changing the refresh interval without selecting "Refresh immediately",
  the UI timer now immediately updates to the new interval and completes the
  cycle correctly without getting stuck in "Refreshing..." state.