### PR TITLE
fix: improve HTTP source resilience with ECONNRESET retry handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -1241,8 +1241,6 @@ async function handleMakeHttpRequest(_, url, method, options = {}) {
                         else {
                             requestBody = String(options.body);
                         }
-
-                        console.log('Processed form data:', requestBody);
                     }
                     else if (options.contentType === 'application/json') {
                         if (typeof options.body === 'string') {


### PR DESCRIPTION
Add automatic retry mechanism for HTTP source refresh when encountering ECONNRESET errors, which are common with certain API endpoints. The implementation works in conjunction with existing main process retry logic to provide a more robust error handling system that:

- Detects "ECONNRESET" and "socket hang up" errors
- Shows a user-friendly "Retrying connection..." message
- Attempts the request again after a short delay
- Properly updates UI with successful response after retry
- Preserves full error handling for non-retryable errors

This fix significantly improves reliability when connecting to APIs that occasionally close connections, particularly on first attempt.