### PR TITLE
fix: enable system certificate store for corporate proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
This change enables Electron's system certificate store integration to fix SSL certificate validation errors when connected through corporate proxies like Zscaler. The app will now properly use trusted certificates from the OS certificate store on all platforms (macOS, Windows, Linux).

- Adds app.commandLine.appendSwitch('use-system-ca-store')
- Improves error logging for certificate-related issues
- Works with existing self-signed WSS server certificates
- No security compromises (maintains proper certificate validation)

Resolves the "unable to get local issuer certificate" errors when making HTTPS requests through corporate proxies with custom certificate authorities.