### PR TITLE
fix: use Electron's net module for proper system certificate validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
Replace Node.js http/https modules with Electron's net module in handleMakeHttpRequest to correctly integrate with the system certificate store. This ensures self-signed certificates added to the OS trust store are properly recognized by the app.

- Implement HTTP requests using Electron's net module instead of Node.js http/https
- Properly respect the use-system-ca-store Electron setting for certificate validation
- Add enhanced error detection for both Node.js and Chromium error codes
- Improve error logging for certificate validation errors
- Provide better user-facing error messages for certificate issues

Fixes the issue where self-signed certificates were rejected even when added to the system's certificate store.