### PR TITLE
fix: restore proper handling of URL-encoded form data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {


### PR DESCRIPTION
Fixed an issue where colon-separated form data wasn't being properly processed and converted to URL-encoded format after switching to Electron's net module. This ensures backward compatibility with existing data formats while properly handling form submissions.

- Added proper import of Electron's net module
- Implemented special handling for colon-separated form data
- Added detailed logging for diagnostics
- Maintained compatibility with all existing input formats

Resolves issue with 400 Bad Request responses when using application/x-www-form-urlencoded content type with colon-separated format.