### PR TITLE
feature: add dark theme support with automatic mode by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/renderer/App.dark.less
+++ b/src/renderer/App.dark.less
@@ -1,0 +1,1139 @@
+// Dark theme overrides for the application
+// This file contains dark mode specific styles that override the default light theme
+
+// Dark theme variables
+@dark-bg-primary: #000000;
+@dark-bg-secondary: #1c1c1e;
+@dark-bg-elevated: #2c2c2e;
+@dark-text-primary: #ffffff;
+@dark-text-secondary: #98989d;
+@dark-border: #38383a;
+@dark-border-secondary: #48484a;
+
+// Apply dark theme to body directly
+body.dark {
+  background-color: @dark-bg-primary;
+  color: @dark-text-primary;
+}
+
+// Apply dark theme when the root has dark class
+.dark {
+  // Background colors
+  background-color: @dark-bg-primary;
+  color: @dark-text-primary;
+
+  // Force override Ant Design CSS variables
+  --ant-tabs-card-bg: @dark-bg-elevated !important;
+  --ant-card-bg: @dark-bg-elevated !important;
+
+
+  // App container
+  .app-container {
+    background-color: @dark-bg-primary;
+  }
+
+  // Header
+  .app-header {
+    background-color: @dark-bg-secondary;
+    box-shadow: 0 1px 0 @dark-border;
+
+    .logo-title {
+      .title-version {
+        h3 {
+          color: @dark-text-primary;
+        }
+      }
+    }
+  }
+
+  // Main content
+  .app-content {
+    background: @dark-bg-primary;
+  }
+
+  // Card styles
+  .ant-card {
+    background-color: @dark-bg-secondary;
+    border-color: @dark-border;
+
+    &-head {
+      border-bottom-color: @dark-border;
+      color: @dark-text-primary;
+    }
+
+    &-body {
+      color: @dark-text-primary;
+    }
+  }
+
+  // Form styles
+  .ant-form-item-label > label {
+    color: @dark-text-primary;
+  }
+
+  // Source form card
+  .source-form-card {
+    .ant-divider {
+      border-color: @dark-border;
+    }
+  }
+
+  // Sticky header
+  .source-form-sticky-header {
+    background: @dark-bg-secondary;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+
+    .title {
+      color: @dark-text-primary;
+    }
+  }
+
+  // HTTP options with very high specificity
+  .http-options {
+    // Override the light theme's #fafafa background with exact selector
+    .ant-tabs-content {
+      background: @dark-bg-elevated !important;
+      padding: 8px !important;
+      border: 1px solid @dark-border !important;
+      border-radius: 0 0 6px 6px !important;
+    }
+
+    // Card tab content with maximum specificity
+    .ant-tabs-card > .ant-tabs-content-holder > .ant-tabs-content {
+      background: @dark-bg-elevated !important;
+      border: 1px solid @dark-border !important;
+      padding: 8px !important;
+    }
+
+    pre {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border-color: @dark-border !important;
+    }
+
+    // Response preview in tabs
+    .response-preview {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border-color: @dark-border !important;
+    }
+
+    // Form fields in HTTP options
+    .ant-form-item {
+      color: @dark-text-primary !important;
+    }
+  }
+
+  // Response preview
+  .response-preview-card {
+    background: @dark-bg-secondary !important;
+    
+    .ant-card-head {
+      background: @dark-bg-secondary !important;
+      border-bottom-color: @dark-border !important;
+    }
+
+    .ant-card-body {
+      background: @dark-bg-secondary !important;
+    }
+
+    // Tab styling inside response preview
+    .ant-tabs {
+      .ant-tabs-nav {
+        background: transparent !important;
+        
+        &::before {
+          border-bottom-color: @dark-border !important;
+        }
+      }
+
+      .ant-tabs-content {
+        background: @dark-bg-elevated !important;
+        border-color: @dark-border !important;
+      }
+    }
+    
+    .response-body, .response-raw {
+      background: @dark-bg-elevated !important;
+      border-color: @dark-border !important;
+      color: @dark-text-primary !important;
+    }
+
+    // Filtered response display
+    .filtered-response {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border-color: @dark-border !important;
+    }
+
+    // Pre/code blocks in response
+    pre {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border-color: @dark-border !important;
+    }
+
+    .response-headers {
+      .headers-table {
+        th {
+          background-color: @dark-bg-elevated;
+          color: @dark-text-primary;
+          border-bottom-color: @dark-border;
+        }
+
+        td {
+          border-bottom-color: @dark-border;
+          color: @dark-text-primary;
+        }
+
+        tr:hover td {
+          background-color: @dark-bg-elevated;
+        }
+      }
+
+      .no-headers {
+        color: @dark-text-secondary;
+      }
+    }
+
+    .filter-info {
+      color: #b37feb;
+    }
+  }
+
+  // Table styles
+  .source-table {
+    .ant-table {
+      background: @dark-bg-secondary;
+
+      .ant-table-thead > tr > th {
+        background: @dark-bg-elevated;
+        color: @dark-text-primary;
+        border-bottom-color: @dark-border;
+      }
+
+      .ant-table-tbody > tr > td {
+        border-bottom-color: @dark-border;
+        color: @dark-text-primary;
+      }
+
+      .ant-table-tbody > tr:hover > td {
+        background: @dark-bg-elevated;
+      }
+    }
+  }
+
+  // Source content cell - Override light theme #fafafa
+  .source-content-cell {
+    background: @dark-bg-elevated !important;
+    border-color: @dark-border !important;
+    color: @dark-text-primary !important;
+  }
+
+  // Refresh status
+  .refresh-status {
+    background: @dark-bg-elevated;
+    color: @dark-text-primary;
+
+    &.active {
+      background: rgba(10, 132, 255, 0.2);
+      color: #0a84ff;
+      border-color: #0a84ff;
+    }
+
+    &.error {
+      background: rgba(255, 77, 79, 0.2);
+      color: #ff4d4f;
+      border-color: #ff4d4f;
+    }
+  }
+
+  // Modal styles
+  .ant-modal-content {
+    background-color: @dark-bg-secondary;
+
+    .ant-modal-header {
+      background-color: @dark-bg-secondary;
+      border-bottom-color: @dark-border;
+
+      .ant-modal-title {
+        color: @dark-text-primary;
+      }
+    }
+
+    .ant-modal-body {
+      color: @dark-text-primary;
+    }
+
+    .ant-modal-footer {
+      background-color: @dark-bg-secondary;
+      border-top-color: @dark-border;
+    }
+  }
+
+  // Input styles
+  .ant-input,
+  .ant-select-selector,
+  .ant-textarea {
+    background-color: @dark-bg-elevated;
+    border-color: @dark-border-secondary;
+    color: @dark-text-primary;
+
+    &:hover,
+    &:focus {
+      border-color: #0a84ff;
+      background-color: @dark-bg-elevated;
+    }
+
+    &::placeholder {
+      color: @dark-text-secondary;
+    }
+  }
+
+  .ant-input-affix-wrapper {
+    background-color: @dark-bg-elevated;
+    border-color: @dark-border-secondary;
+
+    &:hover,
+    &:focus {
+      border-color: #0a84ff;
+    }
+  }
+
+  // Select dropdown
+  .ant-select-dropdown {
+    background-color: @dark-bg-elevated;
+    border-color: @dark-border;
+
+    .ant-select-item {
+      color: @dark-text-primary;
+
+      &-option-selected {
+        background-color: rgba(10, 132, 255, 0.2);
+      }
+
+      &-option-active {
+        background-color: @dark-bg-secondary;
+      }
+    }
+  }
+
+  // Button styles
+  .ant-btn {
+    &-default {
+      background-color: @dark-bg-elevated;
+      border-color: @dark-border-secondary;
+      color: @dark-text-primary;
+
+      &:hover {
+        background-color: @dark-bg-secondary;
+        border-color: #0a84ff;
+        color: #0a84ff;
+      }
+    }
+  }
+
+  // Switch styles
+  .ant-switch {
+    background-color: @dark-border-secondary;
+
+    &-checked {
+      background-color: #0a84ff;
+    }
+  }
+
+  // Divider
+  .ant-divider {
+    border-color: @dark-border;
+  }
+
+  // Tabs
+  .ant-tabs {
+    .ant-tabs-tab {
+      color: @dark-text-secondary;
+      background: transparent;
+
+      &:hover {
+        color: @dark-text-primary;
+      }
+
+      &-active {
+        color: #0a84ff;
+      }
+    }
+
+    .ant-tabs-ink-bar {
+      background-color: #0a84ff;
+    }
+
+    .ant-tabs-nav {
+      background: @dark-bg-secondary;
+      
+      &::before {
+        border-bottom-color: @dark-border;
+      }
+    }
+
+    .ant-tabs-content-holder {
+      background: @dark-bg-secondary;
+    }
+
+    // Fix tab content areas globally
+    .ant-tabs-content {
+      background: @dark-bg-elevated !important;
+      
+      .ant-tabs-tabpane {
+        background: transparent;
+      }
+    }
+
+    .ant-tabs-card {
+      .ant-tabs-content {
+        background: @dark-bg-elevated;
+      }
+
+      > .ant-tabs-nav {
+        .ant-tabs-tab {
+          background: @dark-bg-elevated;
+          border-color: @dark-border;
+
+          &-active {
+            background: @dark-bg-secondary;
+            border-bottom-color: @dark-bg-secondary;
+          }
+        }
+      }
+    }
+  }
+
+  // Tooltips
+  .ant-tooltip {
+    .ant-tooltip-inner {
+      background-color: @dark-bg-elevated;
+      color: @dark-text-primary;
+    }
+
+    .ant-tooltip-arrow-content {
+      background-color: @dark-bg-elevated;
+    }
+  }
+
+  // Message and notifications
+  .ant-message-notice-content {
+    background-color: @dark-bg-elevated;
+    color: @dark-text-primary;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .ant-notification-notice {
+    background-color: @dark-bg-elevated;
+    color: @dark-text-primary;
+
+    .ant-notification-notice-message {
+      color: @dark-text-primary;
+    }
+
+    .ant-notification-notice-description {
+      color: @dark-text-secondary;
+    }
+  }
+
+  // Tag styles
+  .ant-tag {
+    background-color: @dark-bg-elevated;
+    border-color: @dark-border;
+    color: @dark-text-primary;
+  }
+
+  // Status code colors in dark mode
+  .status-code {
+    &.status-2xx {
+      background-color: rgba(52, 199, 89, 0.2);
+      color: #30d158;
+    }
+
+    &.status-4xx,
+    &.status-5xx {
+      background-color: rgba(255, 69, 58, 0.2);
+      color: #ff453a;
+    }
+  }
+
+  // Code and pre elements
+  pre, code {
+    background-color: @dark-bg-elevated;
+    color: @dark-text-primary;
+  }
+
+  // Content viewer modal
+  .content-viewer-modal {
+    pre {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border-color: @dark-border !important;
+    }
+  }
+
+  // Edit Source Modal specific styles
+  .edit-source-modal {
+    .ant-modal-content {
+      background-color: @dark-bg-secondary;
+      color: @dark-text-primary;
+    }
+
+    // All form fields in the modal
+    .ant-form-item {
+      color: @dark-text-primary;
+    }
+
+    // HTTP options inside edit modal - MAXIMUM SPECIFICITY
+    .http-options {
+      // Override the exact selector from light theme
+      > .ant-tabs > .ant-tabs-content-holder > .ant-tabs-content {
+        background: @dark-bg-elevated !important;
+        padding: 8px !important;
+        border: 1px solid @dark-border !important;
+        border-radius: 0 0 6px 6px !important;
+      }
+
+      .ant-tabs-content {
+        background: @dark-bg-elevated !important;
+        border-color: @dark-border !important;
+      }
+
+      .ant-card {
+        background: @dark-bg-elevated !important;
+        border-color: @dark-border !important;
+
+        .ant-card-head {
+          background: @dark-bg-elevated !important;
+          border-bottom-color: @dark-border !important;
+        }
+
+        .ant-card-body {
+          background: @dark-bg-elevated !important;
+        }
+      }
+
+      pre {
+        background: @dark-bg-elevated !important;
+        color: @dark-text-primary !important;
+        border-color: @dark-border !important;
+      }
+    }
+
+    // Tab content backgrounds
+    .ant-tabs-tabpane {
+      background: transparent;
+    }
+
+    // Code/JSON display areas
+    .json-display, .response-display {
+      background: @dark-bg-elevated;
+      color: @dark-text-primary;
+      border-color: @dark-border;
+    }
+
+    // Response preview inside edit modal
+    .response-preview-card {
+      background: @dark-bg-secondary !important;
+      
+      .ant-card-body {
+        background: @dark-bg-secondary !important;
+      }
+
+      .response-body, .response-raw, pre {
+        background: @dark-bg-elevated !important;
+        color: @dark-text-primary !important;
+        border-color: @dark-border !important;
+      }
+    }
+
+    // Override all inline styles in this modal
+    div[style*="color: rgba(0, 0, 0, 0.45)"],
+    span[style*="color: rgba(0, 0, 0, 0.45)"] {
+      color: @dark-text-secondary !important;
+    }
+
+    div[style*="color: rgb(29, 29, 31)"],
+    span[style*="color: rgb(29, 29, 31)"] {
+      color: @dark-text-primary !important;
+    }
+  }
+
+  // Content Viewer Modal
+  .content-viewer-modal {
+    .ant-modal-content {
+      background-color: @dark-bg-secondary;
+      color: @dark-text-primary;
+    }
+
+    .content-display {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border: 1px solid @dark-border !important;
+    }
+
+    // All pre elements in content viewer
+    pre {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+      border: 1px solid @dark-border !important;
+    }
+
+    // Filter indicator
+    .filter-indicator {
+      background-color: rgba(10, 132, 255, 0.1) !important;
+      color: #0a84ff !important;
+    }
+  }
+
+  // Settings Modal text fix
+  .settings-modal {
+    .ant-modal-content {
+      color: @dark-text-primary;
+    }
+
+    .ant-form-item {
+      color: @dark-text-primary;
+    }
+
+    .ant-row {
+      color: @dark-text-primary;
+    }
+
+    // Settings labels and descriptions
+    span {
+      color: inherit;
+    }
+    
+    // Fix inline style colors
+    div[style*="color: #1d1d1f"],
+    span[style*="color: #1d1d1f"] {
+      color: @dark-text-primary !important;
+    }
+    
+    div[style*="color: #86868b"],
+    span[style*="color: #86868b"] {
+      color: @dark-text-secondary !important;
+    }
+    
+    // Fix description text colors
+    span[style*="color: rgba(0, 0, 0, 0.45)"] {
+      color: @dark-text-secondary !important;
+    }
+    
+    span[style*="color: rgba(0, 0, 0, 0.3)"] {
+      color: rgba(255, 255, 255, 0.3) !important;
+    }
+    
+    // Fix icon colors
+    .anticon {
+      &[style*="color: #0071e3"] {
+        color: #0a84ff !important;
+      }
+      
+      &[style*="color: #86868b"] {
+        color: @dark-text-secondary !important;
+      }
+    }
+  }
+
+  // About Modal
+  .about-modal {
+    .ant-modal-content {
+      color: @dark-text-primary;
+    }
+
+    p, span, div {
+      color: @dark-text-primary;
+    }
+
+    a {
+      color: #0a84ff;
+
+      &:hover {
+        color: #409eff;
+      }
+    }
+  }
+
+  // Dropdown menus
+  .ant-dropdown {
+    .ant-dropdown-menu {
+      background-color: @dark-bg-elevated;
+      border-color: @dark-border;
+
+      .ant-dropdown-menu-item {
+        color: @dark-text-primary;
+
+        &:hover {
+          background-color: @dark-bg-secondary;
+        }
+
+        &-divider {
+          background-color: @dark-border;
+        }
+      }
+    }
+  }
+
+  // All text elements default
+  p, span, label, .ant-typography {
+    color: @dark-text-primary;
+  }
+
+  // Override ALL elements with inline styles containing light colors
+  * {
+    &[style*="color: rgba(0, 0, 0, 0.45)"] {
+      color: @dark-text-secondary !important;
+    }
+
+    &[style*="color: rgba(0, 0, 0, 0.3)"] {
+      color: rgba(255, 255, 255, 0.3) !important;
+    }
+
+    &[style*="color: rgb(29, 29, 31)"] {
+      color: @dark-text-primary !important;
+    }
+
+    &[style*="color: rgb(134, 134, 139)"] {
+      color: @dark-text-secondary !important;
+    }
+
+    &[style*="background-color: rgb(240, 248, 255)"] {
+      background-color: rgba(10, 132, 255, 0.1) !important;
+    }
+
+    &[style*="color: rgb(0, 102, 204)"] {
+      color: #0a84ff !important;
+    }
+  }
+
+  // Code elements
+  code {
+    background: rgba(255, 255, 255, 0.1) !important;
+    color: @dark-text-primary !important;
+    padding: 2px 4px;
+    border-radius: 3px;
+  }
+
+  // Force all Ant components to have proper dark background
+  .ant-tabs-tabpane {
+    background: transparent !important;
+  }
+
+  // Force dark background on ALL tab content areas with very specific selectors
+  .ant-tabs-card > .ant-tabs-content-holder > .ant-tabs-content {
+    background: @dark-bg-elevated !important;
+    border: 1px solid @dark-border !important;
+    border-radius: 0 0 6px 6px !important;
+    
+    > .ant-tabs-tabpane {
+      background: transparent !important;
+    }
+  }
+
+  // Specific override for modal tabs
+  .ant-modal-body {
+    .ant-tabs-card {
+      .ant-tabs-content {
+        background: @dark-bg-elevated !important;
+        border-color: @dark-border !important;
+      }
+      
+      .ant-tabs-nav {
+        .ant-tabs-tab {
+          background: transparent;
+          border-color: @dark-border;
+          color: @dark-text-secondary;
+          
+          &.ant-tabs-tab-active {
+            background: @dark-bg-elevated !important;
+            border-bottom-color: @dark-bg-elevated !important;
+            color: @dark-text-primary;
+          }
+        }
+      }
+    }
+  }
+
+  // Code blocks and pre elements everywhere
+  pre, code, .ant-typography pre {
+    background: @dark-bg-elevated !important;
+    color: @dark-text-primary !important;
+    border-color: @dark-border !important;
+  }
+
+  // JSON viewer in modals
+  .json-viewer, .json-display {
+    background: @dark-bg-elevated !important;
+    color: @dark-text-primary !important;
+    
+    pre {
+      background: @dark-bg-elevated !important;
+      color: @dark-text-primary !important;
+    }
+  }
+
+  // Response viewer specific fixes
+  .response-content, .filtered-content {
+    background: @dark-bg-elevated !important;
+    color: @dark-text-primary !important;
+    border-color: @dark-border !important;
+  }
+
+  // Scrollbar styling for webkit browsers
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: @dark-bg-primary;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: @dark-border-secondary;
+    border-radius: 4px;
+
+    &:hover {
+      background: #58585a;
+    }
+  }
+}
+
+// Additional modal fixes with higher specificity
+.dark {
+  // Force modal content to use dark theme
+  .ant-modal-wrap {
+    .ant-modal {
+      .ant-modal-content {
+        background-color: @dark-bg-secondary !important;
+        color: @dark-text-primary !important;
+
+        .ant-modal-header {
+          background-color: @dark-bg-secondary !important;
+          border-bottom-color: @dark-border !important;
+          
+          .ant-modal-title {
+            color: @dark-text-primary !important;
+          }
+        }
+
+        .ant-modal-body {
+          background-color: @dark-bg-secondary !important;
+          color: @dark-text-primary !important;
+          
+          // All text elements in modal body
+          * {
+            color: inherit !important;
+          }
+        }
+
+        .ant-modal-footer {
+          background-color: @dark-bg-secondary !important;
+          border-top-color: @dark-border !important;
+        }
+      }
+    }
+  }
+
+  // Fix form labels in modals
+  .ant-modal {
+    .ant-form-item-label {
+      > label {
+        color: @dark-text-primary !important;
+      }
+    }
+    
+    // Fix all text, spans, and divs
+    span, div, p, label {
+      color: @dark-text-primary !important;
+    }
+  }
+
+  // Fix tab styling in modals
+  .ant-modal {
+    .ant-tabs {
+      &.ant-tabs-card {
+        .ant-tabs-tab {
+          background: transparent !important;
+          border-color: @dark-border !important;
+          color: @dark-text-secondary !important;
+          
+          &.ant-tabs-tab-active {
+            background: @dark-bg-elevated !important;
+            border-bottom-color: @dark-bg-elevated !important;
+            color: @dark-text-primary !important;
+          }
+        }
+        
+        .ant-tabs-content {
+          background: @dark-bg-elevated !important;
+          border: 1px solid @dark-border !important;
+          border-top: none !important;
+          
+          .ant-tabs-tabpane {
+            background: transparent !important;
+          }
+        }
+      }
+    }
+  }
+
+  // Override inline styles with very specific selectors
+  .ant-modal-wrap {
+    // Target all divs with light mode inline styles
+    div[style*="background-color: rgb(255, 255, 255)"],
+    div[style*="background-color: #ffffff"],
+    div[style*="background-color: white"],
+    div[style*="background: rgb(255, 255, 255)"],
+    div[style*="background: #ffffff"],
+    div[style*="background: white"] {
+      background-color: @dark-bg-secondary !important;
+    }
+    
+    // Target all elements with light mode text colors
+    *[style*="color: rgb(0, 0, 0)"],
+    *[style*="color: #000000"],
+    *[style*="color: black"] {
+      color: @dark-text-primary !important;
+    }
+  }
+
+  // Fix switch component in modals
+  .ant-modal {
+    .ant-switch {
+      background-color: @dark-border-secondary !important;
+      
+      &.ant-switch-checked {
+        background-color: #0a84ff !important;
+      }
+    }
+  }
+
+  // Fix any remaining white backgrounds in modals
+  .ant-modal-content {
+    * {
+      &[style*="background-color: #f5f5f7"],
+      &[style*="background-color: rgb(245, 245, 247)"],
+      &[style*="background: #f5f5f7"],
+      &[style*="background: rgb(245, 245, 247)"] {
+        background-color: @dark-bg-elevated !important;
+      }
+    }
+  }
+}
+
+// Aggressive dark mode fix - Maximum specificity
+body.dark {
+  // Force ALL modals to use dark theme
+  .ant-modal-mask {
+    background-color: rgba(0, 0, 0, 0.75) !important;
+  }
+  
+  .ant-modal-wrap .ant-modal {
+    * {
+      background-color: inherit !important;
+      color: inherit !important;
+    }
+    
+    .ant-modal-content {
+      background-color: #1c1c1e !important;
+      color: #ffffff !important;
+      
+      // Override any background that's not dark
+      [style*="background"] {
+        background-color: #1c1c1e !important;
+      }
+      
+      // Override any text that's not light
+      [style*="color"] {
+        color: #ffffff !important;
+      }
+      
+      // Input fields
+      input, textarea, .ant-input, .ant-textarea, .ant-select-selector {
+        background-color: #2c2c2e !important;
+        border-color: #48484a !important;
+        color: #ffffff !important;
+        
+        &::placeholder {
+          color: #98989d !important;
+        }
+      }
+      
+      // Tabs
+      .ant-tabs-tab {
+        background: transparent !important;
+        color: #98989d !important;
+        
+        &.ant-tabs-tab-active {
+          background: #2c2c2e !important;
+          color: #ffffff !important;
+        }
+      }
+      
+      .ant-tabs-content {
+        background: #2c2c2e !important;
+        padding: 16px !important;
+        
+        pre, code {
+          background: #2c2c2e !important;
+          color: #ffffff !important;
+        }
+      }
+      
+      // Cards
+      .ant-card {
+        background: #2c2c2e !important;
+        border-color: #38383a !important;
+        
+        .ant-card-body {
+          background: #2c2c2e !important;
+        }
+      }
+      
+      // Switches
+      .ant-switch {
+        background-color: #48484a !important;
+        
+        &.ant-switch-checked {
+          background-color: #0a84ff !important;
+        }
+      }
+    }
+  }
+}
+
+// Ultimate dark mode fix for Ant Design 5
+body.dark {
+  // App container and layout
+  #root, .ant-app {
+    background-color: @dark-bg-primary !important;
+    color: @dark-text-primary !important;
+  }
+
+  // Force modal root to be dark
+  .ant-modal-root {
+    .ant-modal-mask {
+      background-color: rgba(0, 0, 0, 0.75) !important;
+    }
+    
+    .ant-modal-wrap {
+      .ant-modal {
+        .ant-modal-content {
+          background-color: @dark-bg-secondary !important;
+          color: @dark-text-primary !important;
+          
+          .ant-modal-header,
+          .ant-modal-body,
+          .ant-modal-footer {
+            background-color: @dark-bg-secondary !important;
+            color: @dark-text-primary !important;
+          }
+        }
+      }
+    }
+  }
+
+  // Specific fixes for About Modal inline styles
+  .about-modal {
+    .ant-modal-body {
+      // Override the gradient background
+      background: @dark-bg-secondary !important;
+      
+      // Override inline styles with attribute selectors
+      &[style*="background: linear-gradient"] {
+        background: @dark-bg-secondary !important;
+      }
+    }
+
+    // Fix hardcoded text colors
+    .ant-typography {
+      &[style*="color: rgb(134, 134, 139)"] {
+        color: @dark-text-secondary !important;
+      }
+      
+      &[style*="color: rgb(29, 29, 31)"] {
+        color: @dark-text-primary !important;
+      }
+    }
+
+    // Fix close button background
+    .ant-btn {
+      &[style*="background: rgb(245, 245, 247)"] {
+        background: @dark-bg-elevated !important;
+        border-color: @dark-border !important;
+        color: @dark-text-primary !important;
+      }
+    }
+
+    // Ensure all text in about modal is visible
+    .about-content {
+      * {
+        color: inherit !important;
+      }
+      
+      .ant-typography {
+        color: @dark-text-primary !important;
+      }
+      
+      // Fix tab selection buttons
+      .ant-btn-primary {
+        background-color: #0a84ff !important;
+        border-color: #0a84ff !important;
+        color: #ffffff !important;
+        
+        &:hover {
+          background-color: #0051d5 !important;
+          border-color: #0051d5 !important;
+        }
+      }
+      
+      .ant-btn-text {
+        color: @dark-text-secondary !important;
+        
+        &:hover {
+          color: @dark-text-primary !important;
+        }
+      }
+    }
+  }
+  
+  // Fix dropdown menu icons
+  .ant-dropdown {
+    .ant-dropdown-menu {
+      .ant-dropdown-menu-item {
+        .ant-dropdown-menu-item-icon {
+          color: @dark-text-primary !important;
+        }
+        
+        .anticon {
+          color: @dark-text-primary !important;
+          margin-right: 8px;
+        }
+      }
+    }
+  }
+  
+  // Fix Select dropdown for theme options
+  .ant-select-dropdown {
+    .ant-select-item {
+      .anticon {
+        color: @dark-text-primary !important;
+      }
+      
+      .ant-space {
+        color: @dark-text-primary !important;
+      }
+      
+      &.ant-select-item-option-selected {
+        .anticon {
+          color: #0a84ff !important;
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -18,6 +18,7 @@ import UpdateNotification from './components/UpdateNotification';
 import TrayMenu from './components/TrayMenu';
 import { useSources } from './contexts/SourceContext';
 import { useSettings } from './contexts/SettingsContext';
+import { useTheme } from './contexts/ThemeContext';
 const { createLogger } = require('./utils/logger');
 const log = createLogger('App');
 import { WebSocketProvider } from './contexts/WebSocketContext';
@@ -39,6 +40,7 @@ const AppComponent = () => {
     } = useSources();
 
     const { settings, saveSettings } = useSettings();
+    const { isDarkMode } = useTheme();
 
     const [settingsVisible, setSettingsVisible] = useState(false);
     const [aboutModalVisible, setAboutModalVisible] = useState(false);
@@ -88,6 +90,7 @@ const AppComponent = () => {
             }
         };
     }, [sources, refreshSource]);
+
 
     // Handle add source
     const handleAddSource = async (sourceData) => {
@@ -256,7 +259,7 @@ const AppComponent = () => {
     return (
         // Wrap the entire application with WebSocketProvider
         <WebSocketProvider>
-            <Layout className="app-container">
+            <Layout className={`app-container ${isDarkMode ? 'dark' : ''}`}>
                 <Header className="app-header">
                     <div className="logo-title">
                         <img src="./images/icon128.png" alt="Open Headers Logo" className="app-logo" />

--- a/src/renderer/App.less
+++ b/src/renderer/App.less
@@ -3,6 +3,9 @@
 // Import Ant Design styles
 @import 'antd/dist/reset.css';
 
+// Custom variables
+@primary-color: #0071e3;
+
 // Layout styles
 .app-container {
   min-height: 100vh;
@@ -164,7 +167,7 @@
     font-size: 12px;
   }
 
-  .ant-tabs-content {
+  :where(.ant-tabs-content) {
     background: #fafafa;
     padding: 8px;
     border: 1px solid #f0f0f0;
@@ -258,7 +261,7 @@
     margin-bottom: 8px;
   }
 
-  .response-body, .response-raw {
+  :where(.response-body), :where(.response-raw) {
     max-height: 160px;
     padding: 8px;
     font-size: 11px;
@@ -285,7 +288,7 @@
         border-bottom: 1px solid #f0f0f0;
       }
 
-      th {
+      :where(th) {
         background-color: #fafafa;
         font-weight: 500;
       }
@@ -363,7 +366,7 @@
 }
 
 // Source content cell styles
-.source-content-cell {
+:where(.source-content-cell) {
   max-height: 80px;
   overflow: hidden;
   background: #fafafa;
@@ -454,6 +457,17 @@ code {
   }
 }
 
+// Fix Select component alignment for theme dropdown
+.settings-modal {
+  .ant-select {
+    // Ensure consistent padding for the selector
+    .ant-select-selector {
+      padding-left: 11px !important;
+      padding-right: 11px !important;
+    }
+  }
+}
+
 .ant-input-affix-wrapper {
   border-radius: 6px;
 }
@@ -493,4 +507,13 @@ code {
     white-space: pre-wrap;
     word-break: break-word;
   }
+
+  // Filter indicator
+  .filter-indicator {
+    background-color: #f0f8ff;
+    color: #0066cc;
+  }
 }
+
+// Import dark theme styles at the end to ensure higher specificity
+@import './App.dark.less';

--- a/src/renderer/components/ContentViewer.jsx
+++ b/src/renderer/components/ContentViewer.jsx
@@ -300,13 +300,11 @@ const ContentViewer = ({ source, open, onClose }) => {
                     <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                         {/* Updated indicator for filtered content */}
                         {isFilteredContent ? (
-                            <div style={{
-                                backgroundColor: '#f0f8ff',
+                            <div className="filter-indicator" style={{
                                 padding: '4px 8px',
                                 borderRadius: '4px',
                                 marginBottom: '8px',
-                                fontSize: '12px',
-                                color: '#0066cc'
+                                fontSize: '12px'
                             }}>
                                 <Text strong>JSON Filtered:</Text> {filterPath}
                             </div>
@@ -325,16 +323,14 @@ const ContentViewer = ({ source, open, onClose }) => {
                         </Button>
                     </div>
 
-                    <pre style={{
+                    <pre className="content-display" style={{
                         maxHeight: 300,
                         overflow: 'auto',
                         margin: 0,
-                        background: '#f5f5f7',
                         padding: 12,
                         fontFamily: '"SF Mono", Menlo, Monaco, Consolas, monospace',
                         fontSize: 12,
                         borderRadius: 6,
-                        border: '1px solid #f0f0f0',
                         whiteSpace: 'pre-wrap',
                         wordBreak: 'break-word'
                     }}>
@@ -363,16 +359,14 @@ const ContentViewer = ({ source, open, onClose }) => {
                         </Button>
                     </div>
 
-                    <pre style={{
+                    <pre className="content-display" style={{
                         maxHeight: 300,
                         overflow: 'auto',
                         margin: 0,
-                        background: '#f5f5f7',
                         padding: 12,
                         fontFamily: '"SF Mono", Menlo, Monaco, Consolas, monospace',
                         fontSize: 12,
                         borderRadius: 6,
-                        border: '1px solid #f0f0f0',
                         whiteSpace: 'pre-wrap',
                         wordBreak: 'break-word'
                     }}>
@@ -427,6 +421,7 @@ const ContentViewer = ({ source, open, onClose }) => {
             onCancel={onClose}
             width={700}
             destroyOnClose={false}
+            className="content-viewer-modal"
             footer={[
                 <Button key="close" onClick={onClose}>
                     Close
@@ -479,16 +474,14 @@ const ContentViewer = ({ source, open, onClose }) => {
                         </Button>
                     </div>
 
-                    <pre style={{
+                    <pre className="content-display" style={{
                         maxHeight: 300,
                         overflow: 'auto',
                         margin: 0,
-                        background: '#f5f5f7',
                         padding: 12,
                         fontFamily: '"SF Mono", Menlo, Monaco, Consolas, monospace',
                         fontSize: 12,
                         borderRadius: 6,
-                        border: '1px solid #f0f0f0',
                         whiteSpace: 'pre-wrap',
                         wordBreak: 'break-word'
                     }}>

--- a/src/renderer/components/EditSourceModal.jsx
+++ b/src/renderer/components/EditSourceModal.jsx
@@ -545,6 +545,7 @@ const EditSourceModal = ({ source, open, onCancel, onSave, refreshingSourceId })
                 </div>
             }
             open={open}
+            className="edit-source-modal"
             onCancel={handleModalCancel}
             width={800}
             footer={[

--- a/src/renderer/components/SettingsModal.jsx
+++ b/src/renderer/components/SettingsModal.jsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { Modal, Form, Switch, Divider, Button, Row, Col, Typography, Space, Tooltip } from 'antd';
+import { Modal, Form, Switch, Divider, Button, Row, Col, Typography, Space, Tooltip, Select } from 'antd';
 import {
     LoginOutlined,
     EyeInvisibleOutlined,
     AppstoreOutlined,
-    MenuOutlined
+    MenuOutlined,
+    BgColorsOutlined,
+    SyncOutlined,
+    SunOutlined,
+    MoonOutlined
 } from '@ant-design/icons';
+import { useTheme, THEME_MODES } from '../contexts/ThemeContext';
 const { createLogger } = require('../utils/logger');
 const log = createLogger('SettingsModal');
 
@@ -18,14 +23,21 @@ const { Text } = Typography;
 const SettingsModal = ({ open, settings, onCancel, onSave }) => {
     const [form] = Form.useForm();
     const [formValues, setFormValues] = useState(settings || {});
+    const { themeMode, saveThemeSettings } = useTheme();
 
     // When settings or visibility change, update form values
     useEffect(() => {
         if (open && settings) {
-            form.setFieldsValue(settings);
-            setFormValues(settings);
+            form.setFieldsValue({
+                ...settings,
+                theme: themeMode // Add current theme mode
+            });
+            setFormValues({
+                ...settings,
+                theme: themeMode
+            });
         }
-    }, [open, settings, form]);
+    }, [open, settings, form, themeMode]);
 
     // Track form value changes and enforce dependencies
     const handleValuesChange = (changedValues, allValues) => {
@@ -41,12 +53,20 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
     // Handle form submission
     const handleSubmit = () => {
         form.validateFields()
-            .then(values => {
-                // Enforce dependency rule: if launchAtLogin is false, hideOnLaunch must be false
-                if (!values.launchAtLogin) {
-                    values.hideOnLaunch = false;
+            .then(async values => {
+                // Save theme setting separately
+                if (values.theme && values.theme !== themeMode) {
+                    await saveThemeSettings(values.theme);
                 }
-                onSave(values);
+                
+                // Remove theme from values before passing to settings save
+                const { theme, ...settingsValues } = values;
+                
+                // Enforce dependency rule: if launchAtLogin is false, hideOnLaunch must be false
+                if (!settingsValues.launchAtLogin) {
+                    settingsValues.hideOnLaunch = false;
+                }
+                onSave(settingsValues);
             })
             .catch(info => {
                 log.debug('Validation failed:', info);
@@ -110,6 +130,7 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
             open={open}
             onCancel={onCancel}
             width={500}
+            className="settings-modal"
             footer={[
                 <Button key="cancel" onClick={onCancel}>
                     Cancel
@@ -210,6 +231,58 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
                     <Col span={8} style={{ textAlign: 'right' }}>
                         <Form.Item name="showStatusBarIcon" valuePropName="checked" noStyle>
                             <Switch />
+                        </Form.Item>
+                    </Col>
+                </Row>
+
+                <Divider style={{ margin: '16px 0' }} />
+
+                <div style={sectionStyle}>Theme</div>
+
+                <Row style={getOptionStyle(true)} align="middle" justify="space-between">
+                    <Col span={16}>
+                        <div style={getLabelStyle(true)}>
+                            <BgColorsOutlined style={getIconStyle(true)} />
+                            <Space direction="vertical" size={0}>
+                                <span>Appearance</span>
+                                <span style={getDescStyle(true)}>Choose your preferred theme</span>
+                            </Space>
+                        </div>
+                    </Col>
+                    <Col span={8} style={{ textAlign: 'right' }}>
+                        <Form.Item name="theme" noStyle>
+                            <Select 
+                                style={{ width: 120 }}
+                                options={[
+                                    { 
+                                        value: THEME_MODES.AUTO, 
+                                        label: (
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                                <SyncOutlined style={{ fontSize: 12 }} />
+                                                <span>Auto</span>
+                                            </div>
+                                        )
+                                    },
+                                    { 
+                                        value: THEME_MODES.LIGHT, 
+                                        label: (
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                                <SunOutlined style={{ fontSize: 12 }} />
+                                                <span>Light</span>
+                                            </div>
+                                        )
+                                    },
+                                    { 
+                                        value: THEME_MODES.DARK, 
+                                        label: (
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                                <MoonOutlined style={{ fontSize: 12 }} />
+                                                <span>Dark</span>
+                                            </div>
+                                        )
+                                    }
+                                ]}
+                            />
                         </Form.Item>
                     </Col>
                 </Row>

--- a/src/renderer/components/SettingsModal.jsx
+++ b/src/renderer/components/SettingsModal.jsx
@@ -23,7 +23,7 @@ const { Text } = Typography;
 const SettingsModal = ({ open, settings, onCancel, onSave }) => {
     const [form] = Form.useForm();
     const [formValues, setFormValues] = useState(settings || {});
-    const { themeMode, saveThemeSettings } = useTheme();
+    const { themeMode } = useTheme();
 
     // When settings or visibility change, update form values
     useEffect(() => {
@@ -54,19 +54,13 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
     const handleSubmit = () => {
         form.validateFields()
             .then(async values => {
-                // Save theme setting separately
-                if (values.theme && values.theme !== themeMode) {
-                    await saveThemeSettings(values.theme);
-                }
-                
-                // Remove theme from values before passing to settings save
-                const { theme, ...settingsValues } = values;
-                
                 // Enforce dependency rule: if launchAtLogin is false, hideOnLaunch must be false
-                if (!settingsValues.launchAtLogin) {
-                    settingsValues.hideOnLaunch = false;
+                if (!values.launchAtLogin) {
+                    values.hideOnLaunch = false;
                 }
-                onSave(settingsValues);
+                
+                // Pass all values including theme to settings save
+                onSave(values);
             })
             .catch(info => {
                 log.debug('Validation failed:', info);
@@ -235,16 +229,12 @@ const SettingsModal = ({ open, settings, onCancel, onSave }) => {
                     </Col>
                 </Row>
 
-                <Divider style={{ margin: '16px 0' }} />
-
-                <div style={sectionStyle}>Theme</div>
-
                 <Row style={getOptionStyle(true)} align="middle" justify="space-between">
                     <Col span={16}>
                         <div style={getLabelStyle(true)}>
                             <BgColorsOutlined style={getIconStyle(true)} />
                             <Space direction="vertical" size={0}>
-                                <span>Appearance</span>
+                                <span>Theme</span>
                                 <span style={getDescStyle(true)}>Choose your preferred theme</span>
                             </Space>
                         </div>

--- a/src/renderer/contexts/SettingsContext.jsx
+++ b/src/renderer/contexts/SettingsContext.jsx
@@ -12,7 +12,8 @@ const defaultSettings = {
     launchAtLogin: true,
     hideOnLaunch: true,
     showDockIcon: true,
-    showStatusBarIcon: true
+    showStatusBarIcon: true,
+    theme: 'auto' // auto, light, dark
 };
 
 export function SettingsProvider({ children }) {

--- a/src/renderer/contexts/ThemeContext.jsx
+++ b/src/renderer/contexts/ThemeContext.jsx
@@ -1,0 +1,285 @@
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
+import { ConfigProvider, theme } from 'antd';
+import { showMessage } from '../utils/messageUtil';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('ThemeContext');
+
+// Create context
+const ThemeContext = createContext();
+
+// Theme modes
+export const THEME_MODES = {
+    AUTO: 'auto',
+    LIGHT: 'light',
+    DARK: 'dark'
+};
+
+// Default theme settings
+const defaultThemeSettings = {
+    mode: THEME_MODES.AUTO, // auto, light, dark
+    currentTheme: 'light' // actual theme being used
+};
+
+export function ThemeProvider({ children }) {
+    const [themeSettings, setThemeSettings] = useState(defaultThemeSettings);
+    const [loading, setLoading] = useState(true);
+    const isMounted = useRef(true);
+    const mediaQueryRef = useRef(null);
+
+    useEffect(() => {
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    // Handle system theme changes
+    const handleSystemThemeChange = (e) => {
+        if (themeSettings.mode === THEME_MODES.AUTO && isMounted.current) {
+            const systemTheme = e.matches ? 'dark' : 'light';
+            setThemeSettings(prev => ({
+                ...prev,
+                currentTheme: systemTheme
+            }));
+            log.debug(`System theme changed to: ${systemTheme}`);
+        }
+    };
+
+    // Detect system theme preference
+    const detectSystemTheme = () => {
+        if (window.matchMedia) {
+            const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+            return darkModeQuery.matches ? 'dark' : 'light';
+        }
+        return 'light'; // Default to light if matchMedia not supported
+    };
+
+    // Load theme settings on mount
+    useEffect(() => {
+        const loadThemeSettings = async () => {
+            try {
+                // Try to load saved theme settings
+                const savedSettings = await window.electronAPI.loadFromStorage('theme-settings.json');
+                const settings = JSON.parse(savedSettings);
+                
+                // Determine current theme based on mode
+                let currentTheme = settings.mode;
+                if (settings.mode === THEME_MODES.AUTO) {
+                    currentTheme = detectSystemTheme();
+                }
+                
+                if (isMounted.current) {
+                    setThemeSettings({
+                        mode: settings.mode,
+                        currentTheme
+                    });
+                }
+            } catch (error) {
+                // This is expected on first run when no theme settings exist
+                log.debug('No saved theme settings found, using system theme');
+                
+                // Fall back to system theme
+                const systemTheme = detectSystemTheme();
+                if (isMounted.current) {
+                    setThemeSettings({
+                        mode: THEME_MODES.AUTO,
+                        currentTheme: systemTheme
+                    });
+                }
+            } finally {
+                if (isMounted.current) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        loadThemeSettings();
+    }, []);
+
+    // Set up media query listener after theme settings are loaded
+    useEffect(() => {
+        if (window.matchMedia && themeSettings.mode === THEME_MODES.AUTO) {
+            const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+            mediaQueryRef.current = darkModeQuery;
+            
+            // Add listener for system theme changes
+            darkModeQuery.addEventListener('change', handleSystemThemeChange);
+            
+            // Cleanup
+            return () => {
+                darkModeQuery.removeEventListener('change', handleSystemThemeChange);
+            };
+        }
+    }, [themeSettings.mode]);
+
+    // Apply dark class to body element when theme changes
+    useEffect(() => {
+        if (themeSettings.currentTheme === 'dark') {
+            document.body.classList.add('dark');
+        } else {
+            document.body.classList.remove('dark');
+        }
+        
+        // Cleanup
+        return () => {
+            document.body.classList.remove('dark');
+        };
+    }, [themeSettings.currentTheme]);
+
+    // Save theme settings
+    const saveThemeSettings = async (mode) => {
+        try {
+            // Determine the current theme based on the new mode
+            let currentTheme = mode;
+            if (mode === THEME_MODES.AUTO) {
+                currentTheme = detectSystemTheme();
+            }
+
+            const newSettings = {
+                mode,
+                currentTheme
+            };
+
+            // Save to storage
+            await window.electronAPI.saveToStorage('theme-settings.json', JSON.stringify({ mode }));
+            
+            if (isMounted.current) {
+                setThemeSettings(newSettings);
+                log.debug(`Theme mode changed to: ${mode}, current theme: ${currentTheme}`);
+            }
+            
+            return true;
+        } catch (error) {
+            log.error('Error saving theme settings:', error);
+            if (isMounted.current) {
+                showMessage('error', 'Failed to save theme settings');
+            }
+            return false;
+        }
+    };
+
+    // Get Ant Design theme config based on current theme
+    const getAntdThemeConfig = () => {
+        const isDark = themeSettings.currentTheme === 'dark';
+        
+        return {
+            algorithm: isDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+            token: {
+                // Primary color
+                colorPrimary: isDark ? '#0a84ff' : '#0071e3',
+                
+                // Background colors
+                colorBgContainer: isDark ? '#1c1c1e' : '#ffffff',
+                colorBgElevated: isDark ? '#2c2c2e' : '#ffffff',
+                colorBgLayout: isDark ? '#000000' : '#f5f5f7',
+                
+                // Text colors
+                colorText: isDark ? '#ffffff' : '#1d1d1f',
+                colorTextSecondary: isDark ? '#98989d' : '#86868b',
+                
+                // Border colors
+                colorBorder: isDark ? '#38383a' : '#d2d2d7',
+                colorBorderSecondary: isDark ? '#48484a' : '#e5e5e7',
+                
+                // Component specific
+                borderRadius: 8,
+                boxShadow: isDark 
+                    ? '0 1px 3px rgba(0, 0, 0, 0.3)' 
+                    : '0 1px 2px rgba(0, 0, 0, 0.06)',
+                
+                // Font
+                fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+            },
+            components: {
+                Layout: {
+                    headerBg: isDark ? '#1c1c1e' : '#ffffff',
+                    bodyBg: isDark ? '#000000' : '#f5f5f7',
+                },
+                Card: {
+                    colorBgContainer: isDark ? '#1c1c1e' : '#ffffff',
+                },
+                Modal: {
+                    contentBg: isDark ? '#1c1c1e' : '#ffffff',
+                    headerBg: isDark ? '#1c1c1e' : '#ffffff',
+                    footerBg: isDark ? '#1c1c1e' : '#ffffff',
+                    titleColor: isDark ? '#ffffff' : '#1d1d1f',
+                    colorText: isDark ? '#ffffff' : '#1d1d1f',
+                    colorTextHeading: isDark ? '#ffffff' : '#1d1d1f',
+                    colorIcon: isDark ? '#98989d' : '#86868b',
+                    colorIconHover: isDark ? '#ffffff' : '#1d1d1f',
+                },
+                Form: {
+                    labelColor: isDark ? '#ffffff' : '#1d1d1f',
+                    colorText: isDark ? '#ffffff' : '#1d1d1f',
+                },
+                Table: {
+                    headerBg: isDark ? '#2c2c2e' : '#f5f5f7',
+                    rowHoverBg: isDark ? '#2c2c2e' : '#f5f5f5',
+                },
+                Input: {
+                    colorBgContainer: isDark ? '#2c2c2e' : '#ffffff',
+                    colorBorder: isDark ? '#48484a' : '#d2d2d7',
+                    hoverBorderColor: isDark ? '#0a84ff' : '#0071e3',
+                    activeBorderColor: isDark ? '#0a84ff' : '#0071e3',
+                },
+                Select: {
+                    colorBgContainer: isDark ? '#2c2c2e' : '#ffffff',
+                    colorBorder: isDark ? '#48484a' : '#d2d2d7',
+                },
+                Button: {
+                    colorBgContainer: isDark ? '#2c2c2e' : '#ffffff',
+                },
+                Switch: {
+                    colorPrimary: isDark ? '#0a84ff' : '#0071e3',
+                    colorPrimaryHover: isDark ? '#0a84ff' : '#0071e3',
+                },
+                Tag: {
+                    defaultBg: isDark ? '#2c2c2e' : '#f5f5f7',
+                    defaultColor: isDark ? '#ffffff' : '#1d1d1f',
+                },
+                Tabs: {
+                    cardBg: isDark ? '#2c2c2e' : '#fafafa',
+                    itemColor: isDark ? '#98989d' : '#86868b',
+                    itemSelectedColor: isDark ? '#0a84ff' : '#0071e3',
+                    itemHoverColor: isDark ? '#ffffff' : '#1d1d1f',
+                    inkBarColor: isDark ? '#0a84ff' : '#0071e3',
+                    cardGutter: 2,
+                    titleFontSize: 14,
+                },
+                Message: {
+                    contentBg: isDark ? '#2c2c2e' : '#ffffff',
+                },
+                Notification: {
+                    colorBgElevated: isDark ? '#2c2c2e' : '#ffffff',
+                },
+            }
+        };
+    };
+
+    // Context value
+    const value = {
+        themeMode: themeSettings.mode,
+        currentTheme: themeSettings.currentTheme,
+        loading,
+        saveThemeSettings,
+        isSystemTheme: themeSettings.mode === THEME_MODES.AUTO,
+        isDarkMode: themeSettings.currentTheme === 'dark'
+    };
+
+    return (
+        <ThemeContext.Provider value={value}>
+            <ConfigProvider theme={getAntdThemeConfig()}>
+                {children}
+            </ConfigProvider>
+        </ThemeContext.Provider>
+    );
+}
+
+// Custom hook for using the theme context
+export function useTheme() {
+    const context = useContext(ThemeContext);
+    if (!context) {
+        throw new Error('useTheme must be used within a ThemeProvider');
+    }
+    return context;
+}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { ConfigProvider, theme, App } from 'antd';
+import { App } from 'antd';
 import AppComponent from './App';
 import { SourceProvider } from './contexts/SourceContext';
 import { SettingsProvider } from './contexts/SettingsContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { WebSocketProvider } from './contexts/WebSocketContext';
 import { MessageProvider } from './utils/MessageProvider';
 import { MessageInitializer } from './utils/messageUtil';
@@ -15,20 +16,7 @@ const root = createRoot(container);
 
 // Render the React application with React 18 API and Ant Design App wrapper
 root.render(
-    <ConfigProvider
-        theme={{
-            token: {
-                colorPrimary: '#0071e3',
-                colorSuccess: '#34c759',
-                colorWarning: '#ff9f0a',
-                colorError: '#ff3b30',
-                colorInfo: '#0071e3',
-                borderRadius: 6,
-                fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", Arial, sans-serif',
-            },
-            algorithm: theme.defaultAlgorithm,
-        }}
-    >
+    <ThemeProvider>
         <App
             message={{ maxCount: 5 }}
             notification={{
@@ -50,5 +38,5 @@ root.render(
                 </SettingsProvider>
             </MessageProvider>
         </App>
-    </ConfigProvider>
+    </ThemeProvider>
 );

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -16,27 +16,27 @@ const root = createRoot(container);
 
 // Render the React application with React 18 API and Ant Design App wrapper
 root.render(
-    <ThemeProvider>
-        <App
-            message={{ maxCount: 5 }}
-            notification={{
-                top: 70,
-                duration: 3,
-                maxCount: 5,
-                placement: 'topRight'
-            }}
-        >
-            <MessageProvider>
-                {/* This initializer sets up the message API for use outside React components */}
-                <MessageInitializer />
+    <SettingsProvider>
+        <ThemeProvider>
+            <App
+                message={{ maxCount: 5 }}
+                notification={{
+                    top: 70,
+                    duration: 3,
+                    maxCount: 5,
+                    placement: 'topRight'
+                }}
+            >
+                <MessageProvider>
+                    {/* This initializer sets up the message API for use outside React components */}
+                    <MessageInitializer />
 
-                <SettingsProvider>
                     <SourceProvider>
                         {/* Note: WebSocketProvider is now inside App.jsx */}
                         <AppComponent />
                     </SourceProvider>
-                </SettingsProvider>
-            </MessageProvider>
-        </App>
-    </ThemeProvider>
+                </MessageProvider>
+            </App>
+        </ThemeProvider>
+    </SettingsProvider>
 );


### PR DESCRIPTION
feature: add dark theme support with automatic mode by default

- Add dark theme overrides for Settings, Edit Source, Content Viewer, and About modals
- Fix root cause by applying dark class to body element when in dark mode
- Update ThemeContext with enhanced modal, form, and tabs theme configuration
- Ensure proper text visibility and contrast in all dark mode modals