### PR TITLE
fix: implement singleton instance lock to prevent multiple app instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-headers",
-  "version": "2.11.0",
-  "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
+  "version": "2.12.0",
+  "description": "Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {
     "start": "electron .",
@@ -134,7 +134,7 @@
         "Categories": "Utility;Development;Network"
       },
       "synopsis": "Manage dynamic sources from files, environment variables, and HTTP endpoints",
-      "description": "Companion app for the Open Headers browser extension that manages dynamic sources from files, environment variables, and HTTP endpoints."
+      "description": "Open Headers - companion app for browser extension that manages dynamic sources from files, environment variables, and HTTP endpoints."
     },
     "deb": {
       "depends": [


### PR DESCRIPTION
Fixes the issue where multiple instances of the app could run simultaneously, causing multiple tray icons to appear (especially on Windows).

Implementation details:
- Add singleton instance lock using app.requestSingleInstanceLock()
- Prevent multiple instances in production, allow in development mode
- Focus existing window when second instance is attempted
- Flash taskbar icon on Windows for user attention
- Handle crash recovery with uncaught exception handlers
- Properly release lock during app quit and before updates
- Add --allow-multiple-instances flag for manual override

The singleton lock is bypassed in development mode (NODE_ENV=development or --dev) to allow developers to run multiple instances for testing.

Also includes:
- Bump version to 2.12.0
- Update package description formatting