### PR TITLE
chore: add MIT license and showcase website in About modal

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OpenHeaders
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-headers",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Companion app for Open Headers - Manages dynamic sources from files, environment variables, and HTTP endpoints",
   "main": "dist-webpack/main.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -1310,8 +1310,9 @@ if (!gotTheLock) {
                     return { success: false, error: 'Only HTTPS URLs are allowed' };
                 }
 
-                // Allow GitHub, Chrome Web Store, Microsoft Edge Add-ons, and Mozilla Add-ons
+                // Allow OpenHeaders website, GitHub, Chrome Web Store, Microsoft Edge Add-ons, and Mozilla Add-ons
                 const allowedDomains = [
+                    'openheaders.io',
                     'github.com',
                     'chromewebstore.google.com',
                     'microsoftedge.microsoft.com',

--- a/src/renderer/components/AboutModal.jsx
+++ b/src/renderer/components/AboutModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, Typography, Button, Space, Divider } from 'antd';
-import { GithubOutlined, CompassOutlined } from '@ant-design/icons';
+import { GlobalOutlined, CompassOutlined } from '@ant-design/icons';
 
 const { Title, Text, Link, Paragraph } = Typography;
 
@@ -117,8 +117,9 @@ const AboutModal = ({ open, onClose, appVersion }) => {
                 {activeTab === 'about' ? (
                     <div className="tab-content">
                         <Button
-                            icon={<GithubOutlined />}
-                            onClick={() => openExternal('https://github.com/OpenHeaders/open-headers-app')}
+                            icon={<GlobalOutlined />}
+                            onClick={() => openExternal('https://openheaders.io')}
+                            type="primary"
                             style={{
                                 width: '100%',
                                 marginBottom: '12px',
@@ -126,7 +127,7 @@ const AboutModal = ({ open, onClose, appVersion }) => {
                                 height: '36px'
                             }}
                         >
-                            View on GitHub
+                            Visit Website
                         </Button>
 
                         <Paragraph style={{


### PR DESCRIPTION
- Add LICENSE.md file with MIT license under OpenHeaders organization
- Replace GitHub button with website link (openheaders.io) in About modal
- Update button icon from GithubOutlined to GlobalOutlined
- Add openheaders.io to allowed external domains in main process
- Update package.json version to 2.11.3